### PR TITLE
feat: in-app glob expansion and {%type}/{%ty} template variable

### DIFF
--- a/.crumbs/allow-directory-creation-based-on-file-type.md
+++ b/.crumbs/allow-directory-creation-based-on-file-type.md
@@ -1,0 +1,18 @@
+---
+id: fit-sdx
+title: Allow directory creation based on file type
+status: in_progress
+type: task
+priority: 2
+tags:
+- fitrename
+created: 2026-07-01
+updated: 2026-07-01
+phase: ''
+---
+
+# Allow directory creation based on file type
+
+Fitrename currently allows one to create and organize files into subdirectories based on file information such as year, month, etc. It would be handy to also be able to do this based on the file type (potentially with an option to switch case). This way if one has a directory with FIT, GPX, and TCX files, the same pattern can organize files into separate subdirectories based on the file type.
+
+[start] 2026-07-01 14:03:13

--- a/.crumbs/allow-directory-creation-based-on-file-type.md
+++ b/.crumbs/allow-directory-creation-based-on-file-type.md
@@ -1,7 +1,7 @@
 ---
 id: fit-sdx
 title: Allow directory creation based on file type
-status: in_progress
+status: closed
 type: task
 priority: 2
 tags:
@@ -16,3 +16,5 @@ phase: ''
 Fitrename currently allows one to create and organize files into subdirectories based on file information such as year, month, etc. It would be handy to also be able to do this based on the file type (potentially with an option to switch case). This way if one has a directory with FIT, GPX, and TCX files, the same pattern can organize files into separate subdirectories based on the file type.
 
 [start] 2026-07-01 14:03:13
+
+[stop]  2026-07-01 14:20:18  17m 5s

--- a/.crumbs/fit2json-align-logging-with-other-tools.md
+++ b/.crumbs/fit2json-align-logging-with-other-tools.md
@@ -1,0 +1,26 @@
+---
+id: fit-5c8
+title: "fit2json: align logging with other tools"
+status: open
+tags: [fit2json, tech-debt, logging]
+---
+
+# fit2json: align logging with other tools
+
+fit2json was adapted from an external example and differs from the other three
+tools in its logging setup:
+
+- Logging is hardcoded to `LevelFilter::Info` via `env_logger::Builder` directly
+- No `-v`/`-q` verbose/quiet flags (all other tools support these via `utilities::build_log()`)
+- Uses Clap derive API; others use builder API with a separate `cli.rs` module
+
+**Recommended fix (targeted, not a full rewrite):**
+
+1. Replace the hardcoded log init with `utilities::build_log(&cli_args)`
+2. Adjust CLI to pass `cli_args` to `build_log` — may require switching from derive
+   to builder API, or keeping derive and extracting verbosity flags separately
+
+**Out of scope:** positional `files` vs `--read`/`-r` naming — fit2json's
+positional style is fine for a one-shot conversion tool.
+
+Noted during fit-sdx PR review (PR #137).

--- a/.crumbs/fit2json-document-clap-derive-feature-exception.md
+++ b/.crumbs/fit2json-document-clap-derive-feature-exception.md
@@ -1,0 +1,16 @@
+---
+id: fit-b7s
+title: 'fit2json: document clap derive feature exception'
+status: open
+type: task
+priority: 2
+tags:
+- fit2json
+- clap
+- tech-debt
+created: 2026-07-01
+updated: 2026-07-01
+phase: ''
+---
+
+# fit2json: document clap derive feature exception

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Miscellaneous Tasks
 
-- Migrate workspace to Rust 2024 edition and clean up lints
+- Update CHANGELOG and close fit-sdx crumb
 
 ## [0.5.1] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+### Documentation
+
+- Add fit-sdx implementation plan
+
+### Features
+
+- Add expand_globs() for in-app glob expansion
+- Expand glob patterns in-application
+- Expand glob patterns in-application
+- Add {%type}/{%ty} variable and --type-case flag
+
+### Miscellaneous Tasks
+
+- Migrate workspace to Rust 2024 edition and clean up lints
+
 ## [0.5.1] - 2026-07-01
 
 ### Miscellaneous Tasks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ All notable changes to this project will be documented in this file.
 
 - Add expand_globs() for in-app glob expansion
 - Expand glob patterns in-application
-- Expand glob patterns in-application
 - Add {%type}/{%ty} variable and --type-case flag
 
 ### Miscellaneous Tasks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "fitrename"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "assay",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "fitexport"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "assay",
  "clap",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "fitview"
-version = "0.4.8"
+version = "0.5.0"
 dependencies = [
  "assay",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "gpx"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,7 +1035,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utilities"
-version = "0.4.12"
+version = "0.5.0"
 dependencies = [
  "assay",
  "chrono",
@@ -1038,6 +1044,7 @@ dependencies = [
  "csv",
  "env_logger",
  "fitparser",
+ "glob",
  "gpx",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fit2json"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -337,6 +337,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "utilities",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,6 @@ gpx = "0.10"
 tcx = "0.9"
 assay = "0.1"
 convert_case = "0.11"
+glob = "0.3"
 serde_json = "1"
 uom = { version = "0.38", default-features = false }

--- a/docs/plans/2026-07-01-fit-sdx.md
+++ b/docs/plans/2026-07-01-fit-sdx.md
@@ -1111,7 +1111,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 ```bash
 # Test in-app glob expansion in fit2json (quoted glob, not expanded by shell)
 fit2json '*.fit'   # should process all .fit files in current dir
-fit2json '*.xyz'   # expected: warns "No files matched pattern: *.xyz", falls through to stdin
+fit2json '*.xyz'   # expected: warns "No files matched pattern: *.xyz", exits cleanly (no stdin fallthrough)
 
 # Test {%type} routing — should show fit/ and gpx/ as move targets
 fitrename '*.fit' '*.gpx' \
@@ -1146,5 +1146,5 @@ fitview '*.xyz'
 - **Why warn-and-skip for no-match:** Consistent with each tool's existing per-file error handling — per-item errors don't abort the whole run.
 - **Why `glob 0.3` not `globset`:** The tools advertise shell-style wildcards (`*`, `?`, `[a-z]`). `glob 0.3` matches that contract exactly. `globset` adds `**` recursion which is out of scope here.
 - **Why `fit2json` gets `utilities` as a new dep:** `expand_globs()` lives in `utilities` (the agreed-upon location for shared code). The transitive dependency cost is negligible in a workspace where everything is compiled once.
-- **Behavioural change in `fit2json` for unmatched globs:** Previously, if a user passed a pattern that matched nothing (e.g. `fit2json '*.xyz'`), the literal string `*.xyz` would be passed to `File::open()` and fail with a file-not-found error. After this change, an unmatched pattern warns and `files` is empty, so `fit2json` falls through to stdin mode. This is intentional and consistent with how the other tools handle no-match — silent abort is avoided. If the previous error-on-no-match behaviour was relied upon in scripts, note the change.
+- **Behavioural change in `fit2json` for unmatched globs:** Previously, if a user passed a pattern that matched nothing (e.g. `fit2json '*.xyz'`), the literal string `*.xyz` would be passed to `File::open()` and fail with a file-not-found error. After this change, an unmatched pattern warns (via `expand_globs()`) and `fit2json` exits cleanly with code 0 — it does **not** fall through to stdin mode (stdin mode only triggers when no file arguments are supplied at all). This is consistent with how the other tools handle no-match.
 - **`get_extension()` always returns lowercase:** The `{%type}` injection calls `utilities::get_extension()` which normalises extension case to lowercase before returning. The `--type-case lower` mode therefore requires no transform; `--type-case upper` applies `to_uppercase()` to an already-lowercase string. No mixed-case extension values will appear in `{%type}` or `{%ty}` output.

--- a/docs/plans/2026-07-01-fit-sdx.md
+++ b/docs/plans/2026-07-01-fit-sdx.md
@@ -1,0 +1,1150 @@
+---
+tags:
+  - fitrename
+  - fitutils
+  - glob
+  - feature
+aliases: []
+doc_id: PLAN-fit-sdx
+doc_name: fit-sdx-implementation-plan
+crumb_id: fit-sdx
+document_title: "fit-sdx: File-Type Directories and In-App Globbing"
+created_date: 2026-07-01
+synopsis: "Implementation plan for adding {%type}/{%ty} pattern variable to fitrename and in-application glob expansion across all four fitutils tools."
+status: active
+type: plan
+revision: "1.3"
+review_date: 2026-07-01
+reviewed_by: [Claude]
+completed_date:
+comments:
+revision_history:
+  - date: 2026-07-01
+    author: Claude
+    notes: Initial plan created after structured interview
+  - date: 2026-07-01
+    author: Claude
+    notes: "1.1: Fix Step 1.2 expected output (todo! panics at runtime, not compile error); add Cargo.lock to Steps 2.9/3.12/4.12 git add commands; add from-versions to File Map version bumps; clarify expand_globs doc comment for non-existent literal paths"
+  - date: 2026-07-01
+    author: Claude
+    notes: "1.2: File Map — add missing fitexport/src/cli.rs and fitview/src/cli.rs entries; merge duplicate fit2json/Cargo.toml rows; reorder rows by crate for clarity. Step 4.8 Change B — replace contradictory line-number anchor ('after line 48') with semantic anchor ('between move_pattern binding and let mut total_files'). Step 3.8 — clarify that fitview has no trace-log loop; trace! line is preserved in place and prints an improved expanded Vec<String> after replacement."
+  - date: 2026-07-01
+    author: Claude
+    notes: "1.3: Add missing lint step to Task 2 (Step 2.8: cargo lclippy for fit2json); renumber former Steps 2.8/2.9 → 2.9/2.10. All other tasks (1, 3, 4) already had lint steps — this was the only gap."
+---
+
+# fit-sdx: File-Type Directories and In-App Globbing
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `{%type}/{%ty}` template variable to `fitrename` so files can be organized into subdirectories by format (fit/gpx/tcx), a `--type-case upper|lower` flag to control its casing, and in-application glob expansion to all four fitutils tools so wildcard patterns actually work inside the tools rather than relying on the shell.
+
+**Architecture:** A new `expand_globs()` utility function in `utilities/src/glob_expand.rs` uses the `glob` crate to expand shell-style patterns into a sorted, deduplicated list of paths, warning on no-match. All four binaries call `expand_globs()` on their raw input file list before processing. The `{%type}` and `{%ty}` keys are injected into fitrename's value HashMap inside the `Ok(mut values)` arm (immediately before `rename_and_move()` is called), with case transformation driven by `--type-case`.
+
+**Tech Stack:** Rust 2024 edition, Clap 4 (builder pattern), `glob 0.3`, `log`, `env_logger`.
+
+## Global Constraints
+
+- Rust edition 2024 in all crates.
+- Clap 4 with `features = ["cargo", "env"]` from the workspace — do not add additional clap features.
+- `fit2json` currently has no `utilities` dependency; this plan adds it.
+- Never hard-delete: the existing `std::fs::rename` approach in fitrename is retained.
+- All lint warnings must be zero — `cargo lclippy -- -W clippy::pedantic -W clippy::nursery -W clippy::unwrap_used` must be clean.
+- Version bumps follow semver; these tools are pre-1.0 but new user-visible features warrant a minor bump.
+- Run `cargo lcheck --color always` (not `cargo build`) for fast error checks.
+- Run `cargo nextest run` (not `cargo test`).
+- Commit with `git mit es` before `git commit` (if git-mit is available).
+
+---
+
+## File Map
+
+| Action | Path | Reason |
+|--------|------|--------|
+| Create | `utilities/src/glob_expand.rs` | New `expand_globs()` function |
+| Modify | `Cargo.toml` (workspace root) | Add `glob = "0.3"` to `[workspace.dependencies]` |
+| Modify | `utilities/Cargo.toml` | Add `glob = { workspace = true }`; bump version `0.4.12` → `0.5.0` (new public API) |
+| Modify | `utilities/src/lib.rs` | Export `expand_globs` |
+| Modify | `fit2json/Cargo.toml` | Add `utilities = { path = "../utilities" }`; bump version `0.1.7` → `0.2.0` |
+| Modify | `fit2json/src/main.rs` | Call `expand_globs()` on `cli.files` |
+| Modify | `fitexport/src/cli.rs` | Update `"read"` help text to mention in-app glob expansion |
+| Modify | `fitexport/src/main.rs` | Call `expand_globs()` on `"read"` args |
+| Modify | `fitexport/Cargo.toml` | Bump version `0.1.2` → `0.2.0` |
+| Modify | `fitview/src/cli.rs` | Update `"read"` help text to mention in-app glob expansion |
+| Modify | `fitview/src/main.rs` | Call `expand_globs()` on `"read"` args |
+| Modify | `fitview/Cargo.toml` | Bump version `0.4.8` → `0.5.0` |
+| Modify | `fitrename/src/cli.rs` | Add `--type-case` arg; update help text for `read` and `move` |
+| Modify | `fitrename/src/main.rs` | Call `expand_globs()`; inject `%type`/`%ty` into HashMap |
+| Modify | `fitrename/src/rename_file.rs` | Add tests for `{%type}` substitution |
+| Modify | `fitrename/Cargo.toml` | Bump version `0.5.5` → `0.6.0` |
+
+---
+
+## Task 0: Branch and Plan Document
+
+**Files:**
+
+- Create: `docs/plans/2026-07-01-fit-sdx.md`
+- [ ] **Step 0.1: Create the feature branch**
+
+```bash
+git checkout -b feat/fit-sdx
+```
+
+Expected: prompt changes to `feat/fit-sdx`.
+
+- [ ] **Step 0.2: Start the crumb**
+
+```bash
+crumbs start fit-sdx
+```
+
+- [ ] **Step 0.3: Commit**
+
+```bash
+git mit es
+git add docs/plans/2026-07-01-fit-sdx.md .crumbs/
+git commit -m "docs: add fit-sdx implementation plan
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 1: glob Crate + expand_globs() Utility
+
+**Files:**
+
+- Modify: `Cargo.toml` (workspace root)
+- Modify: `utilities/Cargo.toml`
+- Create: `utilities/src/glob_expand.rs`
+- Modify: `utilities/src/lib.rs`
+
+**Interfaces:**
+
+- Produces: `pub fn expand_globs(patterns: &[String]) -> Vec<String>`
+  - Input: raw file path strings that may contain shell glob characters.
+  - Output: sorted, deduplicated list of matching absolute or relative paths.
+  - Side effect: `log::warn!` for patterns that match no files or are invalid.
+
+- [ ] **Step 1.1: Write the failing tests**
+
+Create `utilities/src/glob_expand.rs` with tests only (no implementation yet):
+
+```rust
+// utilities/src/glob_expand.rs
+
+/// Expands a list of file-path strings and glob patterns into a sorted,
+/// deduplicated list of existing file paths.
+///
+/// Each element of `patterns` may be a literal path or a shell-style glob
+/// (`*`, `?`, `[a-z]`). If an element matches no files — whether because it
+/// is a glob that matches nothing or a literal path that does not exist — a
+/// `warn!` log is emitted and that element contributes nothing to the output.
+///
+/// The result is sorted lexicographically and deduplicated so that processing
+/// order is deterministic regardless of filesystem iteration order.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use utilities::expand_globs;
+/// let files = expand_globs(&["*.fit".to_string()]);
+/// // returns sorted Vec<String> of matched paths
+/// ```
+pub fn expand_globs(patterns: &[String]) -> Vec<String> {
+    todo!("implement")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs, path::Path};
+
+    fn make_files(dir: &Path, names: &[&str]) {
+        for name in names {
+            fs::write(dir.join(name), b"").expect("create temp file");
+        }
+    }
+
+    fn temp_dir(suffix: &str) -> std::path::PathBuf {
+        let d = std::env::temp_dir().join(format!("fitutils_glob_{suffix}"));
+        fs::create_dir_all(&d).expect("create temp dir");
+        d
+    }
+
+    #[test]
+    fn test_literal_path_returns_itself() {
+        let tmp = temp_dir("literal");
+        let file = tmp.join("test.fit");
+        fs::write(&file, b"").unwrap();
+
+        let path_str = file.to_string_lossy().into_owned();
+        let result = expand_globs(&[path_str.clone()]);
+        assert_eq!(result, vec![path_str]);
+
+        fs::remove_file(file).unwrap();
+        fs::remove_dir(tmp).unwrap();
+    }
+
+    #[test]
+    fn test_glob_results_are_sorted() {
+        let tmp = temp_dir("sorted");
+        make_files(&tmp, &["c.fit", "a.fit", "b.fit"]);
+
+        let pattern = tmp.join("*.fit").to_string_lossy().into_owned();
+        let result = expand_globs(&[pattern]);
+
+        let mut expected: Vec<String> = ["a.fit", "b.fit", "c.fit"]
+            .iter()
+            .map(|n| tmp.join(n).to_string_lossy().into_owned())
+            .collect();
+        expected.sort();
+        assert_eq!(result, expected);
+
+        for n in &["a.fit", "b.fit", "c.fit"] {
+            fs::remove_file(tmp.join(n)).unwrap();
+        }
+        fs::remove_dir(tmp).unwrap();
+    }
+
+    #[test]
+    fn test_overlapping_patterns_deduplicated() {
+        let tmp = temp_dir("dedup");
+        let file = tmp.join("2024_run.fit");
+        fs::write(&file, b"").unwrap();
+
+        let exact = file.to_string_lossy().into_owned();
+        let glob_pat = tmp.join("*.fit").to_string_lossy().into_owned();
+        // Same file matched by both the literal path and the glob
+        let result = expand_globs(&[exact.clone(), glob_pat]);
+        assert_eq!(result, vec![exact]);
+
+        fs::remove_file(file).unwrap();
+        fs::remove_dir(tmp).unwrap();
+    }
+
+    #[test]
+    fn test_no_match_returns_empty() {
+        let tmp = temp_dir("nomatch");
+        let pattern = tmp.join("*.fit").to_string_lossy().into_owned();
+        let result = expand_globs(&[pattern]);
+        assert!(result.is_empty());
+        fs::remove_dir(tmp).unwrap();
+    }
+
+    #[test]
+    fn test_mixed_literal_and_glob() {
+        let tmp = temp_dir("mixed");
+        make_files(&tmp, &["run.gpx", "ride.fit", "walk.fit"]);
+
+        let literal = tmp.join("run.gpx").to_string_lossy().into_owned();
+        let glob_pat = tmp.join("*.fit").to_string_lossy().into_owned();
+        let result = expand_globs(&[literal.clone(), glob_pat]);
+
+        let mut expected: Vec<String> = vec![
+            tmp.join("ride.fit").to_string_lossy().into_owned(),
+            tmp.join("run.gpx").to_string_lossy().into_owned(),
+            tmp.join("walk.fit").to_string_lossy().into_owned(),
+        ];
+        expected.sort();
+        assert_eq!(result, expected);
+
+        for n in &["run.gpx", "ride.fit", "walk.fit"] {
+            fs::remove_file(tmp.join(n)).unwrap();
+        }
+        fs::remove_dir(tmp).unwrap();
+    }
+}
+```
+
+- [ ] **Step 1.2: Run tests — expect runtime failures (todo!)**
+
+```bash
+cargo nextest run -p utilities 2>&1 | head -50
+```
+
+Expected: all 5 tests **compile cleanly** but **fail at runtime** with `not yet implemented: implement`. In Rust, `todo!()` is valid syntax that expands to a panic — there is no compile error. Tests can't pass yet.
+
+- [ ] **Step 1.3: Add glob to workspace Cargo.toml**
+
+In `Cargo.toml` (workspace root), add to `[workspace.dependencies]`:
+
+```toml
+glob = "0.3"
+```
+
+- [ ] **Step 1.4: Add glob to utilities/Cargo.toml**
+
+In `utilities/Cargo.toml`, add to `[dependencies]`:
+
+```toml
+glob = { workspace = true }
+```
+
+- [ ] **Step 1.5: Implement expand_globs()**
+
+Replace the `todo!("implement")` body in `utilities/src/glob_expand.rs`:
+
+```rust
+use glob::glob;
+use std::collections::BTreeSet;
+
+pub fn expand_globs(patterns: &[String]) -> Vec<String> {
+    let mut result: BTreeSet<String> = BTreeSet::new();
+
+    for pattern in patterns {
+        match glob(pattern) {
+            Err(e) => log::warn!("Invalid glob pattern '{pattern}': {e}"),
+            Ok(entries) => {
+                let mut matched = false;
+                for entry in entries {
+                    match entry {
+                        Ok(path) => {
+                            matched = true;
+                            result.insert(path.to_string_lossy().into_owned());
+                        }
+                        Err(e) => log::warn!("Glob error in '{pattern}': {e}"),
+                    }
+                }
+                if !matched {
+                    log::warn!("No files matched pattern: {pattern}");
+                }
+            }
+        }
+    }
+
+    result.into_iter().collect()
+}
+```
+
+- [ ] **Step 1.6: Export from utilities/src/lib.rs**
+
+Add `mod glob_expand;` to the module list and add to the final `pub use crate::{...}` block:
+
+```rust
+mod glob_expand;
+// ...
+pub use crate::{
+    build_logs::build_log,
+    duration::Duration,
+    extensions::{get_extension, set_extension},
+    glob_expand::expand_globs,  // ← add this line
+};
+```
+
+The full `lib.rs` becomes:
+
+```rust
+mod build_logs;
+mod datetime_keys;
+mod duration;
+mod extensions;
+mod fit;
+mod glob_expand;
+mod gpx;
+mod macros;
+mod tcx;
+
+pub use crate::fit::{
+    activities::FITActivities, activity::FITActivity, hrzones::FITHrZones, lap::FITLap,
+    record::FITRecord, session::FITSession, to_hashmap::fit_to_hashmap,
+};
+
+pub use crate::gpx::{
+    activities::GPXActivities, activity::GPXActivity, gpxmetadata::GPXMetadata, link::GPXLink,
+    route::GPXRoute, to_hashmap::gpx_to_hashmap, track::GPXTrack, waypoint::GPXWaypoint,
+};
+
+pub use crate::tcx::{
+    activity::{TCXActivitiesList, TCXActivity},
+    to_hashmap::tcx_to_hashmap,
+    trackpoints::{TCXTrackpoint, TCXTrackpointList},
+};
+
+pub use crate::{
+    build_logs::build_log,
+    duration::Duration,
+    extensions::{get_extension, set_extension},
+    glob_expand::expand_globs,
+};
+```
+
+- [ ] **Step 1.7: Run tests — expect PASS**
+
+```bash
+cargo nextest run -p utilities 2>&1
+```
+
+Expected: all 5 new tests pass alongside any existing tests.
+
+- [ ] **Step 1.8: Bump utilities version**
+
+`utilities` gained a new public export (`expand_globs`). This is a minor version bump.
+In `utilities/Cargo.toml`: `version = "0.4.12"` → `version = "0.5.0"`.
+
+- [ ] **Step 1.9: Lint check**
+
+```bash
+cargo lclippy -p utilities -- -W clippy::pedantic -W clippy::nursery -W clippy::unwrap_used 2>&1
+```
+
+Expected: zero warnings. Fix any issues before continuing.
+
+- [ ] **Step 1.10: Commit**
+
+> **Note:** Adding the `glob` crate updates `Cargo.lock`. Since `Cargo.lock` is tracked in this repo (binary workspace), include it in the commit.
+
+```bash
+git mit es
+git add Cargo.lock Cargo.toml utilities/Cargo.toml utilities/src/glob_expand.rs utilities/src/lib.rs
+git commit -m "feat(utilities): add expand_globs() for in-app glob expansion
+
+Adds a new public function that expands shell-style glob patterns into a
+sorted, deduplicated Vec<String> of matching file paths. Patterns with no
+matches emit a warn! log and contribute nothing to the output. Backed by
+the glob 0.3 crate, added as a workspace dependency.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Wire expand_globs() into fit2json
+
+**Files:**
+
+- Modify: `fit2json/Cargo.toml`
+- Modify: `fit2json/src/main.rs`
+
+**Interfaces:**
+
+- Consumes: `utilities::expand_globs(&[String]) -> Vec<String>` (from Task 1)
+
+- [ ] **Step 2.1: Write the failing test**
+
+fit2json's `run()` is not easily unit-tested end-to-end without real FIT files. We verify the expansion code path compiles and handles empty-after-expansion correctly. Add to `fit2json/src/main.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn expand_globs_empty_on_no_match() {
+        // A pattern that matches nothing should return empty (warn is logged).
+        let result = utilities::expand_globs(&["/tmp/fitutils_nonexistent_*.fit".to_string()]);
+        assert!(result.is_empty());
+    }
+}
+```
+
+- [ ] **Step 2.2: Run test — expect compile error (utilities not in deps yet)**
+
+```bash
+cargo nextest run -p fit2json 2>&1 | head -20
+```
+
+Expected: compile error — `utilities` not found.
+
+- [ ] **Step 2.3: Add utilities dependency to fit2json/Cargo.toml**
+
+In `fit2json/Cargo.toml`, add to `[dependencies]`:
+
+```toml
+utilities = { path = "../utilities" }
+```
+
+- [ ] **Step 2.4: Run test again — expect PASS**
+
+```bash
+cargo nextest run -p fit2json 2>&1
+```
+
+Expected: test passes (utilities found, glob returns empty for nonexistent pattern).
+
+- [ ] **Step 2.5: Wire expand_globs() into fit2json/src/main.rs**
+
+In `run()`, after `let cli = Cli::parse();` and before the `if cli.files.is_empty()` stdin check, insert glob expansion. Replace:
+
+**Before:**
+
+```rust
+let cli = Cli::parse();
+let output_loc = cli
+    .output
+    .map_or(types::OutputLocation::Inplace, types::OutputLocation::new);
+let collect_all = matches!(output_loc, types::OutputLocation::LocalFile(_));
+
+// If no files have been provided, read from STDIN
+if cli.files.is_empty() {
+```
+
+**After:**
+
+```rust
+let cli = Cli::parse();
+let output_loc = cli
+    .output
+    .map_or(types::OutputLocation::Inplace, types::OutputLocation::new);
+let collect_all = matches!(output_loc, types::OutputLocation::LocalFile(_));
+
+// Expand any glob patterns in the file list.  On Unix the shell usually handles
+// this, but in-app expansion supports quoted globs, scripts, and Windows.
+let files: Vec<std::path::PathBuf> = if cli.files.is_empty() {
+    Vec::new()
+} else {
+    let raw: Vec<String> = cli
+        .files
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    utilities::expand_globs(&raw)
+        .into_iter()
+        .map(std::path::PathBuf::from)
+        .collect()
+};
+
+// If no files have been provided (or none matched globs), read from STDIN
+if files.is_empty() {
+```
+
+Then update the processing loop from `for file in cli.files {` to `for file in files {`. The loop body is unchanged.
+
+- [ ] **Step 2.6: Run all tests**
+
+```bash
+cargo nextest run -p fit2json 2>&1
+```
+
+Expected: tests pass.
+
+- [ ] **Step 2.7: Quick check**
+
+```bash
+cargo lcheck -p fit2json --color always 2>&1
+```
+
+Expected: no errors or warnings.
+
+- [ ] **Step 2.8: Lint check**
+
+```bash
+cargo lclippy -p fit2json -- -W clippy::pedantic -W clippy::nursery -W clippy::unwrap_used 2>&1
+```
+
+Expected: zero warnings. Fix any issues before continuing.
+
+- [ ] **Step 2.9: Bump fit2json version**
+
+In `fit2json/Cargo.toml`: `version = "0.1.7"` → `version = "0.2.0"`.
+
+- [ ] **Step 2.10: Commit**
+
+```bash
+git mit es
+git add Cargo.lock fit2json/Cargo.toml fit2json/src/main.rs
+git commit -m "feat(fit2json): expand glob patterns in-application
+
+Glob patterns such as '*.fit' are now expanded by the application rather
+than relying on the shell. Patterns with no matches emit a warning; an
+empty-after-expansion list falls through to stdin mode. Adds utilities as
+a direct dependency.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Wire expand_globs() into fitexport and fitview
+
+**Files:**
+
+- Modify: `fitexport/src/main.rs`
+- Modify: `fitview/src/main.rs`
+- Modify: `fitexport/Cargo.toml`
+- Modify: `fitview/Cargo.toml`
+
+**Interfaces:**
+
+- Consumes: `utilities::expand_globs(&[String]) -> Vec<String>` (Task 1)
+- Both tools already depend on `utilities`.
+
+The change pattern is identical in both tools. Apply it to `fitexport` first, then repeat for `fitview`.
+
+### 3a: fitexport
+
+- [ ] **Step 3.1: Write the test for fitexport**
+
+In `fitexport/src/main.rs`, add:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn expand_globs_empty_on_no_match() {
+        let result = utilities::expand_globs(&["/tmp/fitutils_nonexistent_*.fit".to_string()]);
+        assert!(result.is_empty());
+    }
+}
+```
+
+Run:
+
+```bash
+cargo nextest run -p fitexport 2>&1
+```
+
+Expected: test **passes** immediately — `utilities` is already a dependency of `fitexport`, so no dependency change is needed before this test can compile and run.
+
+- [ ] **Step 3.2: Locate the two `get_many("read")` calls in fitexport/src/main.rs**
+
+`fitexport/src/main.rs` has **two** places that call `get_many::<String>("read")`:
+
+1. **Trace-log loop** (near the top, after logging init): iterates to log each argument for debugging. Leave this unchanged — it logs the user's raw input patterns, which is the most useful tracing information.
+2. **Main processing loop** (further down, inside the `for filename in ...` loop that calls `FITActivity::from_file` etc.): this is the one to replace.
+
+- [ ] **Step 3.3: Replace the main processing loop with expand_globs()-based collection**
+
+Collect raw inputs and expand globs **between** the trace-log loop and the main processing loop:
+
+```rust
+let raw_inputs: Vec<String> = cli_args
+    .get_many::<String>("read")
+    .unwrap_or_default()
+    .cloned()
+    .collect();
+let filenames = utilities::expand_globs(&raw_inputs);
+```
+
+Replace the main loop header from:
+
+```rust
+for filename in cli_args
+    .get_many::<String>("read")
+    .unwrap_or_default()
+    .map(std::string::String::as_str)
+{
+```
+
+to:
+
+```rust
+for filename in &filenames {
+    let filename = filename.as_str(); // shadow as &str — rest of loop body unchanged
+```
+
+- [ ] **Step 3.4: Update help text in fitexport/src/cli.rs**
+
+Find the `"read"` argument's `.help(...)` string and update it to:
+
+```
+"One or more .fit, .gpx or .tcx file(s) to process. Glob patterns (e.g. *.fit, 2024*.gpx) are expanded by the application."
+```
+
+- [ ] **Step 3.5: Run tests and lint**
+
+```bash
+cargo nextest run -p fitexport 2>&1
+cargo lclippy -p fitexport -- -W clippy::pedantic -W clippy::nursery -W clippy::unwrap_used 2>&1
+```
+
+Expected: tests pass, zero lint warnings.
+
+- [ ] **Step 3.6: Bump fitexport version**
+
+In `fitexport/Cargo.toml`: `version = "0.1.2"` → `version = "0.2.0"`.
+
+### 3b: fitview (same pattern)
+
+- [ ] **Step 3.7: Write the test for fitview**
+
+In `fitview/src/main.rs`, add:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn expand_globs_empty_on_no_match() {
+        let result = utilities::expand_globs(&["/tmp/fitutils_nonexistent_*.fit".to_string()]);
+        assert!(result.is_empty());
+    }
+}
+```
+
+Run:
+
+```bash
+cargo nextest run -p fitview 2>&1
+```
+
+Expected: test **passes** immediately — `utilities` is already a dependency of `fitview`.
+
+- [ ] **Step 3.8: Apply the same expand_globs() replacement in fitview/src/main.rs**
+
+Same pattern as Step 3.3, with one difference: fitview collects into a named variable (`let filenames = ...`) followed immediately by a `log::trace!` statement — there is no separate trace-log loop. Replace the `let filenames = ...` assignment only; the `log::trace!("main::run() -- Files: {filenames:?}");` line stays in place and will now print the expanded path list (an improvement over printing an iterator's debug repr).
+
+```rust
+let raw_inputs: Vec<String> = cli_args
+    .get_many::<String>("read")
+    .unwrap_or_default()
+    .cloned()
+    .collect();
+let filenames = utilities::expand_globs(&raw_inputs);
+// log::trace! line that follows is unchanged — now prints the expanded Vec<String>
+```
+
+Update the loop:
+
+```rust
+for filename in &filenames {
+    let filename = filename.as_str();
+```
+
+- [ ] **Step 3.9: Update help text in fitview/src/cli.rs**
+
+Update the `"read"` argument help string to:
+
+```
+"One or more .fit, .gpx or .tcx file(s) to process. Glob patterns (e.g. *.fit, 2024*.gpx) are expanded by the application."
+```
+
+- [ ] **Step 3.10: Run tests and lint**
+
+```bash
+cargo nextest run -p fitview 2>&1
+cargo lclippy -p fitview -- -W clippy::pedantic -W clippy::nursery -W clippy::unwrap_used 2>&1
+```
+
+Expected: tests pass, zero warnings.
+
+- [ ] **Step 3.11: Bump fitview version**
+
+In `fitview/Cargo.toml`: `version = "0.4.8"` → `version = "0.5.0"`.
+
+- [ ] **Step 3.12: Commit**
+
+```bash
+git mit es
+git add Cargo.lock fitexport/Cargo.toml fitexport/src/ fitview/Cargo.toml fitview/src/
+git commit -m "feat(fitexport,fitview): expand glob patterns in-application
+
+Glob patterns such as '*.fit' and '2024*.gpx' are now expanded by the
+application rather than relying on the shell. Unmatched patterns emit a
+warning. Updates help text to reflect the new behaviour.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: {%type}/{%ty} + --type-case + glob expansion in fitrename
+
+**Files:**
+
+- Modify: `fitrename/src/cli.rs`
+- Modify: `fitrename/src/main.rs`
+- Modify: `fitrename/src/rename_file.rs` (tests only)
+- Modify: `fitrename/Cargo.toml`
+
+**Interfaces:**
+
+- Consumes: `utilities::expand_globs(&[String]) -> Vec<String>` (Task 1)
+- Consumes: `utilities::get_extension(&str) -> String` (returns lowercase extension without dot)
+- New CLI arg: `--type-case upper|lower` (default `"lower"`)
+- New HashMap keys: `"%type"` and `"%ty"` holding the file extension with applied casing
+
+### 4a: Tests first (rename_file.rs)
+
+- [ ] **Step 4.1: Write failing tests in rename_file.rs**
+
+Append to `fitrename/src/rename_file.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_type_variable_substitution() {
+        let mut values = HashMap::new();
+        values.insert("%year".to_string(), "2024".to_string());
+        values.insert("%type".to_string(), "fit".to_string());
+        values.insert("%ty".to_string(), "fit".to_string());
+
+        // {%type} alone produces the file extension
+        assert_eq!(substitute_pattern("{%type}", &values), "fit");
+        // Short alias produces the same result
+        assert_eq!(substitute_pattern("{%ty}", &values), "fit");
+        // Combined with other variables
+        assert_eq!(
+            substitute_pattern("{%year}-{%type}", &values),
+            "2024-fit"
+        );
+    }
+
+    #[test]
+    fn test_type_variable_uppercase() {
+        let mut values = HashMap::new();
+        values.insert("%type".to_string(), "FIT".to_string());
+        values.insert("%ty".to_string(), "FIT".to_string());
+
+        assert_eq!(substitute_pattern("{%type}", &values), "FIT");
+        assert_eq!(substitute_pattern("{%ty}", &values), "FIT");
+    }
+
+    #[test]
+    fn test_type_variable_for_gpx() {
+        let mut values = HashMap::new();
+        values.insert("%type".to_string(), "gpx".to_string());
+        values.insert("%ty".to_string(), "gpx".to_string());
+
+        assert_eq!(substitute_pattern("{%type}", &values), "gpx");
+    }
+
+    #[test]
+    fn test_type_variable_for_tcx_uppercase() {
+        let mut values = HashMap::new();
+        values.insert("%type".to_string(), "TCX".to_string());
+        values.insert("%ty".to_string(), "TCX".to_string());
+
+        assert_eq!(substitute_pattern("{%type}", &values), "TCX");
+    }
+}
+```
+
+- [ ] **Step 4.2: Run tests**
+
+```bash
+cargo nextest run -p fitrename 2>&1
+```
+
+These tests will likely PASS immediately — `substitute_pattern` already handles any HashMap key. That is expected: the tests are documenting and locking in the behaviour. The implementation work (injecting the keys) comes in Step 4.8.
+
+### 4b: CLI changes
+
+- [ ] **Step 4.3: Write the CLI test extension**
+
+In `fitrename/src/cli.rs`, in the existing `test_cli_build` test:
+
+In the first `build().get_matches_from(...)` call, add `"--type-case", "upper"` to the args vector and add these assertions:
+
+```rust
+assert!(args.contains_id("type-case"));
+assert_eq!(
+    args.get_one::<String>("type-case").map(String::as_str),
+    Some("upper")
+);
+```
+
+In the second `build().get_matches_from(...)` call (short args), verify the default:
+
+```rust
+assert_eq!(
+    args2.get_one::<String>("type-case").map(String::as_str),
+    Some("lower")
+);
+```
+
+- [ ] **Step 4.4: Run test — expect failure**
+
+```bash
+cargo nextest run -p fitrename 2>&1
+```
+
+Expected: test fails — `type-case` arg does not exist yet.
+
+- [ ] **Step 4.5: Add --type-case argument to fitrename/src/cli.rs**
+
+In `cli.rs`, append the following `.arg(...)` chain call before the final closing `}` of `pub fn build() -> Command`:
+
+```rust
+        .arg(
+            Arg::new("type-case")
+                .long("type-case")
+                .help(
+                    "Case for the {%type} and {%ty} pattern variables. \
+                     'upper' produces 'FIT', 'lower' (default) produces 'fit'.",
+                )
+                .value_name("CASE")
+                .value_parser(["upper", "lower"])
+                .default_value("lower")
+                .num_args(1)
+                .action(ArgAction::Set)
+                .required(false),
+        )
+```
+
+Also update the `"read"` arg `.help(...)` to:
+
+```
+"One or more .fit, .gpx or .tcx file(s) to process. Glob patterns (e.g. *.fit, 2024*.gpx) are expanded by the application."
+```
+
+And update the `"move"` arg `.help(...)` to:
+
+```
+"Move the file to the directory specified by this pattern. Use {%type} or {%ty} to organize by file format (e.g. --move \"{%type}\")."
+```
+
+- [ ] **Step 4.6: Run CLI test — expect PASS**
+
+```bash
+cargo nextest run -p fitrename 2>&1
+```
+
+Expected: all existing CLI tests plus the new type-case assertions pass.
+
+### 4c: main.rs changes
+
+- [ ] **Step 4.7: Write a test documenting the get_extension() assumption**
+
+The `{%type}` injection in Step 4.8 calls `utilities::get_extension(filename)` and then applies an optional `to_uppercase()`. A critical precondition is that `get_extension` **already normalises to lowercase** — so the default `lower` case mode requires no transform at all, and `upper` always starts from a clean lowercase base.
+
+Add to `fitrename/src/main.rs` to pin this assumption:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn get_extension_normalises_to_lowercase() {
+        // get_extension() always returns a lowercase string.
+        // The {%type} injection in run() depends on this — the `lower` case
+        // mode needs no transform, and `upper` always starts from lowercase.
+        assert_eq!(utilities::get_extension("workout.FIT"), "fit");
+        assert_eq!(utilities::get_extension("route.gpx"), "gpx");
+        assert_eq!(utilities::get_extension("activity.TCX"), "tcx");
+    }
+}
+```
+
+Run:
+
+```bash
+cargo nextest run -p fitrename 2>&1
+```
+
+Expected: passes (utilities already a dep; `get_extension` already normalises extension case).
+
+- [ ] **Step 4.8: Wire glob expansion and {%type} injection into fitrename/src/main.rs**
+
+Apply four targeted changes to `fitrename/src/main.rs`:
+
+**Change A — Replace the filenames iterator with expand_globs() (lines 23–27):**
+
+Remove:
+
+```rust
+let filenames = cli_args
+    .get_many::<String>("read")
+    .unwrap_or_default()
+    .map(std::string::String::as_str);
+log::trace!("main::run() -- Filenames: {filenames:?}");
+```
+
+Replace with:
+
+```rust
+let raw_inputs: Vec<String> = cli_args
+    .get_many::<String>("read")
+    .unwrap_or_default()
+    .cloned()
+    .collect();
+let filenames = utilities::expand_globs(&raw_inputs);
+log::trace!("main::run() -- Filenames: {filenames:?}");
+```
+
+**Change B — Read --type-case before the loop (insert between the `move_pattern` binding and `let mut total_files`):**
+
+```rust
+let type_case_upper = cli_args
+    .get_one::<String>("type-case")
+    .map(String::as_str) == Some("upper");
+```
+
+**Change C — Update the loop header (line 56):**
+
+```rust
+// Before:
+for filename in filenames {
+
+// After (filenames is now Vec<String>):
+for filename in &filenames {
+    let filename = filename.as_str();
+```
+
+**Change D — Inject %type and %ty inside the Ok(values) arm (line 89):**
+
+Change `Ok(values)` to `Ok(mut values)` and insert the type keys immediately before `let move_pat`:
+
+```rust
+match value_res {
+    Ok(mut values) => {
+        // Inject the file-type template variables ({%type}, {%ty})
+        let ext = utilities::get_extension(filename);
+        let type_val = if type_case_upper {
+            ext.to_uppercase()
+        } else {
+            ext
+        };
+        values.insert("%type".to_string(), type_val.clone());
+        values.insert("%ty".to_string(), type_val);
+
+        let move_pat = if move_files { Some(move_pattern) } else { None };
+        match rename_file::rename_and_move(
+            filename,
+            pattern,
+            move_pat,
+            &values,
+            total_files,
+            dry_run,
+        ) {
+            Ok(new_path) => {
+                log::info!("{filename} --> {new_path}");
+                processed_files += 1;
+            }
+            Err(err) => {
+                log::error!("Unable to process {filename}: {err}");
+                skipped_files += 1;
+            }
+        }
+    }
+    Err(err) => log::error!("Unable to process {filename}: {err}"),
+}
+```
+
+- [ ] **Step 4.9: Run all fitrename tests**
+
+```bash
+cargo nextest run -p fitrename 2>&1
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4.10: Lint check**
+
+```bash
+cargo lclippy -p fitrename -- -W clippy::pedantic -W clippy::nursery -W clippy::unwrap_used 2>&1
+```
+
+Expected: zero warnings. Common clippy issues and fixes:
+
+- The `type_val.clone()` on the first `.insert()` is **intentional**: `type_val` is moved into the second insert, so the clone is required. Do not remove it. Clippy should not flag this under pedantic, but if it does, the fix is to keep the clone, not to remove it.
+- If clippy flags shadowing of `filename`: rename the shadow to `filename_str` and update all uses within the loop body.
+
+- [ ] **Step 4.11: Bump fitrename version**
+
+In `fitrename/Cargo.toml`: `version = "0.5.5"` → `version = "0.6.0"`.
+
+- [ ] **Step 4.12: Commit**
+
+```bash
+git mit es
+git add Cargo.lock fitrename/Cargo.toml fitrename/src/
+git commit -m "feat(fitrename): add {%type}/{%ty} variable and --type-case flag
+
+fitrename can now organize files into subdirectories by format using the
+new {%type} (or short alias {%ty}) pattern variable. For example:
+
+  fitrename '*.fit' '*.gpx' -p '{%year}-{%month}-{%day}' --move '{%type}'
+
+routes FIT files into fit/ and GPX files into gpx/ subdirectories.
+
+--type-case upper|lower (default: lower) controls whether the variable
+emits 'fit' or 'FIT'. In-app glob expansion is also wired in here,
+consistent with the other three tools.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full Workspace Check and CHANGELOG
+
+- [ ] **Step 5.1: Run the full test suite**
+
+```bash
+cargo nextest run --color always 2>&1
+```
+
+Expected: all tests across all crates pass. Zero failures.
+
+- [ ] **Step 5.2: Full workspace lint**
+
+```bash
+cargo lclippy -- -W clippy::pedantic -W clippy::nursery -W clippy::unwrap_used 2>&1
+```
+
+Expected: zero warnings. Fix any issues.
+
+- [ ] **Step 5.3: Update CHANGELOG**
+
+```bash
+just changelog
+```
+
+Expected: `CHANGELOG.md` regenerated with entries for all bumped crates.
+
+- [ ] **Step 5.4: Close the crumb**
+
+```bash
+crumbs close fit-sdx
+```
+
+Only change the `status` field in the frontmatter — do not modify any other fields.
+
+- [ ] **Step 5.5: Final commit**
+
+```bash
+git mit es
+git add CHANGELOG.md .crumbs/
+git commit -m "chore: update CHANGELOG and close fit-sdx crumb
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Verification
+
+**Manual smoke test** (requires actual FIT, GPX, or TCX files in the current directory):
+
+```bash
+# Test in-app glob expansion in fit2json (quoted glob, not expanded by shell)
+fit2json '*.fit'   # should process all .fit files in current dir
+fit2json '*.xyz'   # expected: warns "No files matched pattern: *.xyz", falls through to stdin
+
+# Test {%type} routing — should show fit/ and gpx/ as move targets
+fitrename '*.fit' '*.gpx' \
+  --pattern '{%year}-{%month}-{%day}' \
+  --move '{%type}' \
+  --dry-run
+
+# Test --type-case upper — dirs should be FIT/, GPX/
+fitrename '*.fit' '*.gpx' \
+  --pattern '{%year}-{%month}-{%day}' \
+  --move '{%type}' \
+  --type-case upper \
+  --dry-run
+
+# Test in-app glob expansion (quoted glob, not expanded by shell)
+fitview '*.fit'    # should list all .fit files in current dir
+fitexport '*.gpx'  # should export all .gpx files
+
+# Test that non-matching pattern warns and doesn't crash
+fitview '*.xyz'
+# Expected: warns "No files matched pattern: *.xyz", exits cleanly
+```
+
+**Verify `--help` output** for fitrename shows `--type-case` and updated help text for `--read` and `--move`.
+
+---
+
+## Design Notes
+
+- **Why inject `{%type}` in `main.rs`, not in `*_to_hashmap()`:** The file extension is filesystem metadata, not file-content metadata. The `*_to_hashmap()` functions receive already-parsed content structs, not the source path — adding the extension there would require a signature change across the utilities API. Injection in `main.rs` is simpler and correctly separates concerns.
+- **Why `BTreeSet` in `expand_globs()`:** Provides O(log n) deduplication and a free lexicographic sort in one data structure, with no extra `.dedup()` call needed.
+- **Why warn-and-skip for no-match:** Consistent with each tool's existing per-file error handling — per-item errors don't abort the whole run.
+- **Why `glob 0.3` not `globset`:** The tools advertise shell-style wildcards (`*`, `?`, `[a-z]`). `glob 0.3` matches that contract exactly. `globset` adds `**` recursion which is out of scope here.
+- **Why `fit2json` gets `utilities` as a new dep:** `expand_globs()` lives in `utilities` (the agreed-upon location for shared code). The transitive dependency cost is negligible in a workspace where everything is compiled once.
+- **Behavioural change in `fit2json` for unmatched globs:** Previously, if a user passed a pattern that matched nothing (e.g. `fit2json '*.xyz'`), the literal string `*.xyz` would be passed to `File::open()` and fail with a file-not-found error. After this change, an unmatched pattern warns and `files` is empty, so `fit2json` falls through to stdin mode. This is intentional and consistent with how the other tools handle no-match — silent abort is avoided. If the previous error-on-no-match behaviour was relied upon in scripts, note the change.
+- **`get_extension()` always returns lowercase:** The `{%type}` injection calls `utilities::get_extension()` which normalises extension case to lowercase before returning. The `--type-case lower` mode therefore requires no transform; `--type-case upper` applies `to_uppercase()` to an already-lowercase string. No mixed-case extension values will appear in `{%type}` or `{%ty}` output.

--- a/fit2json/Cargo.toml
+++ b/fit2json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fit2json"
-version = "0.1.7"
+version = "0.2.0"
 authors = ["evensolberg <even.solberg@gmail.com>"]
 edition = "2024"
 license = "Apache-2.0"
@@ -15,3 +15,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 fitparser = { workspace = true }
+utilities = { path = "../utilities" }

--- a/fit2json/src/main.rs
+++ b/fit2json/src/main.rs
@@ -111,11 +111,14 @@ mod tests {
         // match nothing, regardless of any stale files in the OS temp dir.
         let tmp = std::env::temp_dir()
             .join(format!("fitutils_f2j_nomatch_{}", std::process::id()));
+        if tmp.exists() {
+            fs::remove_dir_all(&tmp).expect("remove stale temp dir");
+        }
         fs::create_dir_all(&tmp).expect("create temp dir");
         let pattern = tmp.join("*.fit").to_string_lossy().into_owned();
         let result = utilities::expand_globs(&[pattern]);
         assert!(result.is_empty());
-        fs::remove_dir(tmp).expect("clean up temp dir");
+        fs::remove_dir_all(tmp).expect("clean up temp dir");
     }
 }
 

--- a/fit2json/src/main.rs
+++ b/fit2json/src/main.rs
@@ -72,9 +72,10 @@ fn run() -> Result<(), Box<dyn Error>> {
         return Ok(());
     }
 
-    // If file args were supplied but none matched, warn and exit cleanly
+    // If file args were supplied but none matched, exit cleanly.
+    // expand_globs() already emitted a warn! for each unmatched pattern.
     if files.is_empty() {
-        return Err("No input files matched the supplied patterns".into());
+        return Ok(());
     }
 
     // Read each FIT file and output it

--- a/fit2json/src/main.rs
+++ b/fit2json/src/main.rs
@@ -42,22 +42,32 @@ fn run() -> Result<(), Box<dyn Error>> {
     let collect_all = matches!(output_loc, types::OutputLocation::LocalFile(_));
 
     // Expand glob patterns in-app so quoted globs work consistently across
-    // shells and on Windows.  All inputs (literal paths and patterns alike)
-    // are routed through expand_globs(), which skips non-existent paths and
-    // emits a warning for each unmatched pattern — consistent with the other
-    // fitutils binaries.
-    let raw: Vec<String> = cli
-        .files
-        .iter()
-        .map(|p| p.to_string_lossy().into_owned())
-        .collect();
-    let files: Vec<PathBuf> = utilities::expand_globs(&raw)
-        .into_iter()
-        .map(PathBuf::from)
-        .collect();
+    // shells and on Windows.
+    //
+    // fit2json receives PathBufs from clap, which can include non-UTF-8 paths
+    // on Unix.  Strategy:
+    //   • Path exists on disk   → add as-is (no string conversion, non-UTF-8 safe)
+    //   • Non-existent + UTF-8  → pass to expand_globs() as a glob pattern
+    //   • Non-existent + non-UTF-8 → warn and skip (cannot be a valid glob)
+    let mut files: Vec<PathBuf> = Vec::new();
+    for p in &cli.files {
+        if p.exists() {
+            files.push(p.clone());
+        } else if let Some(s) = p.to_str() {
+            files.extend(
+                utilities::expand_globs(&[s.to_owned()])
+                    .into_iter()
+                    .map(PathBuf::from),
+            );
+        } else {
+            log::warn!("Skipping non-UTF-8 path that does not exist: {}", p.to_string_lossy());
+        }
+    }
+    files.sort();
+    files.dedup();
 
     // If no files have been provided, read from STDIN
-    if raw.is_empty() {
+    if cli.files.is_empty() {
         log::info!("No files supplied. Reading from STDIN.");
         // Force Stdout mode when reading from STDIN with Inplace output
         let effective_output = match &output_loc {

--- a/fit2json/src/main.rs
+++ b/fit2json/src/main.rs
@@ -91,7 +91,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut all_fit_data: Vec<fitparser::FitDataRecord> = Vec::new();
     for file in files {
         // open file and parse data
-        log::info!("Processing file: {}", &file.to_str().unwrap_or_default());
+        log::info!("Processing file: {}", file.to_string_lossy());
         let mut fp = File::open(&file)?;
         let mut data = fitparser::from_reader(&mut fp)?;
 

--- a/fit2json/src/main.rs
+++ b/fit2json/src/main.rs
@@ -103,15 +103,19 @@ fn run() -> Result<(), Box<dyn Error>> {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     #[test]
     fn expand_globs_empty_on_no_match() {
-        // A pattern that matches nothing should return empty (warn is logged).
-        let pattern = std::env::temp_dir()
-            .join(format!("fitutils_nonexistent_{}_*.fit", std::process::id()))
-            .to_string_lossy()
-            .into_owned();
+        // Use an isolated empty temp directory so the glob is guaranteed to
+        // match nothing, regardless of any stale files in the OS temp dir.
+        let tmp = std::env::temp_dir()
+            .join(format!("fitutils_f2j_nomatch_{}", std::process::id()));
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let pattern = tmp.join("*.fit").to_string_lossy().into_owned();
         let result = utilities::expand_globs(&[pattern]);
         assert!(result.is_empty());
+        fs::remove_dir(tmp).expect("clean up temp dir");
     }
 }
 

--- a/fit2json/src/main.rs
+++ b/fit2json/src/main.rs
@@ -41,36 +41,23 @@ fn run() -> Result<(), Box<dyn Error>> {
         .map_or(types::OutputLocation::Inplace, types::OutputLocation::new);
     let collect_all = matches!(output_loc, types::OutputLocation::LocalFile(_));
 
-    // Expand any glob patterns in the file list.  On Unix the shell usually handles
-    // this, but in-app expansion supports quoted globs, scripts, and Windows.
-    //
-    // Paths with glob metacharacters are stringified for expand_globs().
-    // Literal paths are kept as PathBuf to avoid corrupting non-UTF-8 names
-    // via to_string_lossy() replacement characters.
-    let files: Vec<PathBuf> = if cli.files.is_empty() {
-        Vec::new()
-    } else {
-        let is_glob =
-            |p: &PathBuf| p.to_str().is_some_and(|s| s.contains(['*', '?', '[']));
-        let (glob_pats, literal_refs): (Vec<_>, Vec<_>) =
-            cli.files.iter().partition(|p| is_glob(p));
-        // Start with the literal (non-glob) paths, owned.
-        let mut result: Vec<PathBuf> = literal_refs.into_iter().cloned().collect();
-        // Expand each glob pattern and merge, then sort and dedup.
-        if !glob_pats.is_empty() {
-            let raw: Vec<String> = glob_pats
-                .iter()
-                .map(|p| p.to_string_lossy().into_owned())
-                .collect();
-            result.extend(utilities::expand_globs(&raw).into_iter().map(PathBuf::from));
-            result.sort();
-            result.dedup();
-        }
-        result
-    };
+    // Expand glob patterns in-app so quoted globs work consistently across
+    // shells and on Windows.  All inputs (literal paths and patterns alike)
+    // are routed through expand_globs(), which skips non-existent paths and
+    // emits a warning for each unmatched pattern — consistent with the other
+    // fitutils binaries.
+    let raw: Vec<String> = cli
+        .files
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    let files: Vec<PathBuf> = utilities::expand_globs(&raw)
+        .into_iter()
+        .map(PathBuf::from)
+        .collect();
 
     // If no files have been provided, read from STDIN
-    if cli.files.is_empty() {
+    if raw.is_empty() {
         log::info!("No files supplied. Reading from STDIN.");
         // Force Stdout mode when reading from STDIN with Inplace output
         let effective_output = match &output_loc {
@@ -84,8 +71,8 @@ fn run() -> Result<(), Box<dyn Error>> {
         return Ok(());
     }
 
-    // If file args were supplied but none matched, exit cleanly.
-    // expand_globs() already emitted a warn! for each unmatched pattern.
+    // If file args were supplied but none matched (or all are missing),
+    // exit cleanly — expand_globs() already warned for each unmatched entry.
     if files.is_empty() {
         return Ok(());
     }

--- a/fit2json/src/main.rs
+++ b/fit2json/src/main.rs
@@ -101,7 +101,11 @@ mod tests {
     #[test]
     fn expand_globs_empty_on_no_match() {
         // A pattern that matches nothing should return empty (warn is logged).
-        let result = utilities::expand_globs(&["/tmp/fitutils_nonexistent_*.fit".to_string()]);
+        let pattern = format!(
+            "{}/fitutils_nonexistent_*.fit",
+            std::env::temp_dir().to_string_lossy()
+        );
+        let result = utilities::expand_globs(&[pattern]);
         assert!(result.is_empty());
     }
 }

--- a/fit2json/src/main.rs
+++ b/fit2json/src/main.rs
@@ -57,8 +57,8 @@ fn run() -> Result<(), Box<dyn Error>> {
             .collect()
     };
 
-    // If no files have been provided (or none matched globs), read from STDIN
-    if files.is_empty() {
+    // If no files have been provided, read from STDIN
+    if cli.files.is_empty() {
         log::info!("No files supplied. Reading from STDIN.");
         // Force Stdout mode when reading from STDIN with Inplace output
         let effective_output = match &output_loc {
@@ -70,6 +70,11 @@ fn run() -> Result<(), Box<dyn Error>> {
             fitparser::from_reader(&mut std::io::stdin())?,
         )?;
         return Ok(());
+    }
+
+    // If file args were supplied but none matched, warn and exit cleanly
+    if files.is_empty() {
+        return Err("No input files matched the supplied patterns".into());
     }
 
     // Read each FIT file and output it

--- a/fit2json/src/main.rs
+++ b/fit2json/src/main.rs
@@ -43,18 +43,30 @@ fn run() -> Result<(), Box<dyn Error>> {
 
     // Expand any glob patterns in the file list.  On Unix the shell usually handles
     // this, but in-app expansion supports quoted globs, scripts, and Windows.
-    let files: Vec<std::path::PathBuf> = if cli.files.is_empty() {
+    //
+    // Paths with glob metacharacters are stringified for expand_globs().
+    // Literal paths are kept as PathBuf to avoid corrupting non-UTF-8 names
+    // via to_string_lossy() replacement characters.
+    let files: Vec<PathBuf> = if cli.files.is_empty() {
         Vec::new()
     } else {
-        let raw: Vec<String> = cli
-            .files
-            .iter()
-            .map(|p| p.to_string_lossy().into_owned())
-            .collect();
-        utilities::expand_globs(&raw)
-            .into_iter()
-            .map(std::path::PathBuf::from)
-            .collect()
+        let is_glob =
+            |p: &PathBuf| p.to_str().is_some_and(|s| s.contains(['*', '?', '[']));
+        let (glob_pats, literal_refs): (Vec<_>, Vec<_>) =
+            cli.files.iter().partition(|p| is_glob(p));
+        // Start with the literal (non-glob) paths, owned.
+        let mut result: Vec<PathBuf> = literal_refs.into_iter().cloned().collect();
+        // Expand each glob pattern and merge, then sort and dedup.
+        if !glob_pats.is_empty() {
+            let raw: Vec<String> = glob_pats
+                .iter()
+                .map(|p| p.to_string_lossy().into_owned())
+                .collect();
+            result.extend(utilities::expand_globs(&raw).into_iter().map(PathBuf::from));
+            result.sort();
+            result.dedup();
+        }
+        result
     };
 
     // If no files have been provided, read from STDIN
@@ -107,10 +119,10 @@ mod tests {
     #[test]
     fn expand_globs_empty_on_no_match() {
         // A pattern that matches nothing should return empty (warn is logged).
-        let pattern = format!(
-            "{}/fitutils_nonexistent_*.fit",
-            std::env::temp_dir().to_string_lossy()
-        );
+        let pattern = std::env::temp_dir()
+            .join("fitutils_nonexistent_*.fit")
+            .to_string_lossy()
+            .into_owned();
         let result = utilities::expand_globs(&[pattern]);
         assert!(result.is_empty());
     }

--- a/fit2json/src/main.rs
+++ b/fit2json/src/main.rs
@@ -41,8 +41,24 @@ fn run() -> Result<(), Box<dyn Error>> {
         .map_or(types::OutputLocation::Inplace, types::OutputLocation::new);
     let collect_all = matches!(output_loc, types::OutputLocation::LocalFile(_));
 
-    // If no files have been provided, read from STDIN
-    if cli.files.is_empty() {
+    // Expand any glob patterns in the file list.  On Unix the shell usually handles
+    // this, but in-app expansion supports quoted globs, scripts, and Windows.
+    let files: Vec<std::path::PathBuf> = if cli.files.is_empty() {
+        Vec::new()
+    } else {
+        let raw: Vec<String> = cli
+            .files
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        utilities::expand_globs(&raw)
+            .into_iter()
+            .map(std::path::PathBuf::from)
+            .collect()
+    };
+
+    // If no files have been provided (or none matched globs), read from STDIN
+    if files.is_empty() {
         log::info!("No files supplied. Reading from STDIN.");
         // Force Stdout mode when reading from STDIN with Inplace output
         let effective_output = match &output_loc {
@@ -58,7 +74,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
     // Read each FIT file and output it
     let mut all_fit_data: Vec<fitparser::FitDataRecord> = Vec::new();
-    for file in cli.files {
+    for file in files {
         // open file and parse data
         log::info!("Processing file: {}", &file.to_str().unwrap_or_default());
         let mut fp = File::open(&file)?;
@@ -78,6 +94,16 @@ fn run() -> Result<(), Box<dyn Error>> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn expand_globs_empty_on_no_match() {
+        // A pattern that matches nothing should return empty (warn is logged).
+        let result = utilities::expand_globs(&["/tmp/fitutils_nonexistent_*.fit".to_string()]);
+        assert!(result.is_empty());
+    }
 }
 
 /// Main executable entry point. Hands off to the `run` function.

--- a/fit2json/src/main.rs
+++ b/fit2json/src/main.rs
@@ -111,27 +111,6 @@ fn run() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use std::fs;
-
-    #[test]
-    fn expand_globs_empty_on_no_match() {
-        // Use an isolated empty temp directory so the glob is guaranteed to
-        // match nothing, regardless of any stale files in the OS temp dir.
-        let tmp = std::env::temp_dir()
-            .join(format!("fitutils_f2j_nomatch_{}", std::process::id()));
-        if tmp.exists() {
-            fs::remove_dir_all(&tmp).expect("remove stale temp dir");
-        }
-        fs::create_dir_all(&tmp).expect("create temp dir");
-        let pattern = tmp.join("*.fit").to_string_lossy().into_owned();
-        let result = utilities::expand_globs(&[pattern]);
-        assert!(result.is_empty());
-        fs::remove_dir_all(tmp).expect("clean up temp dir");
-    }
-}
-
 /// Main executable entry point. Hands off to the `run` function.
 fn main() {
     std::process::exit(match run() {

--- a/fit2json/src/main.rs
+++ b/fit2json/src/main.rs
@@ -120,7 +120,7 @@ mod tests {
     fn expand_globs_empty_on_no_match() {
         // A pattern that matches nothing should return empty (warn is logged).
         let pattern = std::env::temp_dir()
-            .join("fitutils_nonexistent_*.fit")
+            .join(format!("fitutils_nonexistent_{}_*.fit", std::process::id()))
             .to_string_lossy()
             .into_owned();
         let result = utilities::expand_globs(&[pattern]);

--- a/fitexport/Cargo.toml
+++ b/fitexport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fitexport"
-version = "0.1.2"
+version = "0.2.0"
 description = "Exports FIT, GPX, and TCX activity files to JSON and CSV"
 license = "Apache-2.0"
 authors = ["evensolberg <even.solberg@gmail.com>"]

--- a/fitexport/src/cli.rs
+++ b/fitexport/src/cli.rs
@@ -15,8 +15,8 @@ pub fn build() -> Command {
             Arg::new("read")
                 .value_name("FILE(S)")
                 .help(
-                    "One or more .fit, .gpx, or .tcx files to process. \
-                     Wildcards and mixed formats are supported.",
+                    "One or more .fit, .gpx or .tcx file(s) to process. \
+                     Glob patterns (e.g. *.fit, 2024*.gpx) are expanded by the application.",
                 )
                 .num_args(1..)
                 .required(true)

--- a/fitexport/src/main.rs
+++ b/fitexport/src/main.rs
@@ -236,10 +236,10 @@ fn main() {
 mod tests {
     #[test]
     fn expand_globs_empty_on_no_match() {
-        let pattern = format!(
-            "{}/fitutils_nonexistent_*.fit",
-            std::env::temp_dir().to_string_lossy()
-        );
+        let pattern = std::env::temp_dir()
+            .join("fitutils_nonexistent_*.fit")
+            .to_string_lossy()
+            .into_owned();
         let result = utilities::expand_globs(&[pattern]);
         assert!(result.is_empty());
     }

--- a/fitexport/src/main.rs
+++ b/fitexport/src/main.rs
@@ -20,19 +20,11 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut logbuilder = utilities::build_log(&cli_args);
     logbuilder.target(Target::Stdout).init();
 
-    // Trace-log the input files (raw patterns, before glob expansion)
-    for argument in cli_args
-        .get_many::<String>("read")
-        .unwrap_or_default()
-        .map(std::string::String::as_str)
-    {
-        log::trace!("run() -- Arguments: {argument:?}");
-    }
-
-    // Expand glob patterns into concrete file paths
+    // Collect raw patterns (trace-logged here) then expand into concrete paths.
     let raw_inputs: Vec<String> = cli_args
         .get_many::<String>("read")
         .unwrap_or_default()
+        .inspect(|a| log::trace!("run() -- Arguments: {a:?}"))
         .cloned()
         .collect();
     let filenames = utilities::expand_globs(&raw_inputs);
@@ -230,25 +222,4 @@ fn main() {
             1
         }
     });
-}
-
-#[cfg(test)]
-mod tests {
-    use std::fs;
-
-    #[test]
-    fn expand_globs_empty_on_no_match() {
-        // Use an isolated empty temp directory so the glob is guaranteed to
-        // match nothing, regardless of any stale files in the OS temp dir.
-        let tmp = std::env::temp_dir()
-            .join(format!("fitutils_fex_nomatch_{}", std::process::id()));
-        if tmp.exists() {
-            fs::remove_dir_all(&tmp).expect("remove stale temp dir");
-        }
-        fs::create_dir_all(&tmp).expect("create temp dir");
-        let pattern = tmp.join("*.fit").to_string_lossy().into_owned();
-        let result = utilities::expand_globs(&[pattern]);
-        assert!(result.is_empty());
-        fs::remove_dir_all(tmp).expect("clean up temp dir");
-    }
 }

--- a/fitexport/src/main.rs
+++ b/fitexport/src/main.rs
@@ -237,7 +237,11 @@ fn main() {
 mod tests {
     #[test]
     fn expand_globs_empty_on_no_match() {
-        let result = utilities::expand_globs(&["/tmp/fitutils_nonexistent_*.fit".to_string()]);
+        let pattern = format!(
+            "{}/fitutils_nonexistent_*.fit",
+            std::env::temp_dir().to_string_lossy()
+        );
+        let result = utilities::expand_globs(&[pattern]);
         assert!(result.is_empty());
     }
 }

--- a/fitexport/src/main.rs
+++ b/fitexport/src/main.rs
@@ -242,10 +242,13 @@ mod tests {
         // match nothing, regardless of any stale files in the OS temp dir.
         let tmp = std::env::temp_dir()
             .join(format!("fitutils_fex_nomatch_{}", std::process::id()));
+        if tmp.exists() {
+            fs::remove_dir_all(&tmp).expect("remove stale temp dir");
+        }
         fs::create_dir_all(&tmp).expect("create temp dir");
         let pattern = tmp.join("*.fit").to_string_lossy().into_owned();
         let result = utilities::expand_globs(&[pattern]);
         assert!(result.is_empty());
-        fs::remove_dir(tmp).expect("clean up temp dir");
+        fs::remove_dir_all(tmp).expect("clean up temp dir");
     }
 }

--- a/fitexport/src/main.rs
+++ b/fitexport/src/main.rs
@@ -20,7 +20,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut logbuilder = utilities::build_log(&cli_args);
     logbuilder.target(Target::Stdout).init();
 
-    // Trace-log the input files
+    // Trace-log the input files (raw patterns, before glob expansion)
     for argument in cli_args
         .get_many::<String>("read")
         .unwrap_or_default()
@@ -28,6 +28,14 @@ fn run() -> Result<(), Box<dyn Error>> {
     {
         log::trace!("run() -- Arguments: {argument:?}");
     }
+
+    // Expand glob patterns into concrete file paths
+    let raw_inputs: Vec<String> = cli_args
+        .get_many::<String>("read")
+        .unwrap_or_default()
+        .cloned()
+        .collect();
+    let filenames = utilities::expand_globs(&raw_inputs);
 
     // Determine summary file settings
     let write_summary = cli_args.value_source("summary-file") == Some(ValueSource::CommandLine);
@@ -53,11 +61,8 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut processed_files: usize = 0;
     let mut skipped_files: usize = 0;
 
-    for filename in cli_args
-        .get_many::<String>("read")
-        .unwrap_or_default()
-        .map(std::string::String::as_str)
-    {
+    for filename in &filenames {
+        let filename = filename.as_str();
         total_files += 1;
         log::info!("Processing file: {filename}");
 
@@ -226,4 +231,13 @@ fn main() {
             1
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn expand_globs_empty_on_no_match() {
+        let result = utilities::expand_globs(&["/tmp/fitutils_nonexistent_*.fit".to_string()]);
+        assert!(result.is_empty());
+    }
 }

--- a/fitexport/src/main.rs
+++ b/fitexport/src/main.rs
@@ -237,7 +237,7 @@ mod tests {
     #[test]
     fn expand_globs_empty_on_no_match() {
         let pattern = std::env::temp_dir()
-            .join("fitutils_nonexistent_*.fit")
+            .join(format!("fitutils_nonexistent_{}_*.fit", std::process::id()))
             .to_string_lossy()
             .into_owned();
         let result = utilities::expand_globs(&[pattern]);

--- a/fitexport/src/main.rs
+++ b/fitexport/src/main.rs
@@ -61,8 +61,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut processed_files: usize = 0;
     let mut skipped_files: usize = 0;
 
-    for filename in &filenames {
-        let filename = filename.as_str();
+    for filename in filenames.iter().map(String::as_str) {
         total_files += 1;
         log::info!("Processing file: {filename}");
 

--- a/fitexport/src/main.rs
+++ b/fitexport/src/main.rs
@@ -234,13 +234,18 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     #[test]
     fn expand_globs_empty_on_no_match() {
-        let pattern = std::env::temp_dir()
-            .join(format!("fitutils_nonexistent_{}_*.fit", std::process::id()))
-            .to_string_lossy()
-            .into_owned();
+        // Use an isolated empty temp directory so the glob is guaranteed to
+        // match nothing, regardless of any stale files in the OS temp dir.
+        let tmp = std::env::temp_dir()
+            .join(format!("fitutils_fex_nomatch_{}", std::process::id()));
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let pattern = tmp.join("*.fit").to_string_lossy().into_owned();
         let result = utilities::expand_globs(&[pattern]);
         assert!(result.is_empty());
+        fs::remove_dir(tmp).expect("clean up temp dir");
     }
 }

--- a/fitrename/Cargo.toml
+++ b/fitrename/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "fitrename"
-version = "0.5.5"
+version = "0.6.0"
 edition = "2024"
 description = "Renames .FIT, .GPX and .TCX files based on metadata."
 license = "Apache-2.0"

--- a/fitrename/src/cli.rs
+++ b/fitrename/src/cli.rs
@@ -11,7 +11,7 @@ pub fn build() -> Command {
         .arg(
             Arg::new("read")
                 .value_name("FILE(S)")
-                .help("One or more .fit, .gpx or .tcx file(s) to process. Wildcards and multiple_occurrences files (e.g. 2019*.fit 2020*.gpx) are supported.")
+                .help("One or more .fit, .gpx or .tcx file(s) to process. Glob patterns (e.g. *.fit, 2024*.gpx) are expanded by the application.")
                 .num_args(1..)
                 .required(true)
                 .action(ArgAction::Append),
@@ -30,7 +30,7 @@ pub fn build() -> Command {
             Arg::new("move")
                 .short('m')
                 .long("move")
-                .help("Move the file to the directory specified (patterns allowed).")
+                .help("Move the file to the directory specified by this pattern. Use {%type} or {%ty} to organize by file format (e.g. --move \"{%type}\").")
                 .num_args(1)
                 .value_name("target_directory")
                 .action(ArgAction::Set)
@@ -71,6 +71,20 @@ pub fn build() -> Command {
                 .num_args(0)
                 .action(ArgAction::SetTrue)
         )
+        .arg(
+            Arg::new("type-case")
+                .long("type-case")
+                .help(
+                    "Case for the {%type} and {%ty} pattern variables. \
+                     'upper' produces 'FIT', 'lower' (default) produces 'fit'.",
+                )
+                .value_name("CASE")
+                .value_parser(["upper", "lower"])
+                .default_value("lower")
+                .num_args(1)
+                .action(ArgAction::Set)
+                .required(false),
+        )
 }
 
 #[cfg(test)]
@@ -92,6 +106,8 @@ mod tests {
             "--quiet",
             "--print-summary",
             "--dry-run",
+            "--type-case",
+            "upper",
         ]);
 
         assert!(args.contains_id("read"));
@@ -101,6 +117,11 @@ mod tests {
         assert!(args.contains_id("quiet"));
         assert!(args.contains_id("print-summary"));
         assert!(args.contains_id("dry-run"));
+        assert!(args.contains_id("type-case"));
+        assert_eq!(
+            args.get_one::<String>("type-case").map(String::as_str),
+            Some("upper")
+        );
 
         // Test using short form arguments/flags.
         let args2 = build().get_matches_from(vec![
@@ -123,5 +144,9 @@ mod tests {
         assert!(args2.contains_id("quiet"));
         assert!(args2.contains_id("print-summary"));
         assert!(args2.contains_id("dry-run"));
+        assert_eq!(
+            args2.get_one::<String>("type-case").map(String::as_str),
+            Some("lower")
+        );
     }
 }

--- a/fitrename/src/main.rs
+++ b/fitrename/src/main.rs
@@ -20,10 +20,12 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut logbuilder = utilities::build_log(&cli_args);
     logbuilder.target(Target::Stdout).init();
 
-    let filenames = cli_args
+    let raw_inputs: Vec<String> = cli_args
         .get_many::<String>("read")
         .unwrap_or_default()
-        .map(std::string::String::as_str);
+        .cloned()
+        .collect();
+    let filenames = utilities::expand_globs(&raw_inputs);
     log::trace!("main::run() -- Filenames: {filenames:?}");
 
     if dry_run {
@@ -47,13 +49,18 @@ fn run() -> Result<(), Box<dyn Error>> {
         ""
     };
 
+    let type_case_upper = cli_args
+        .get_one::<String>("type-case")
+        .map(String::as_str) == Some("upper");
+
     let mut total_files: usize = 0;
     let mut processed_files: usize = 0;
     let mut skipped_files: usize = 0;
 
     ///////////////////////////////////
     // Working section
-    for filename in filenames {
+    for filename in &filenames {
+        let filename = filename.as_str();
         total_files += 1;
         log::debug!("Processing file: {filename}");
 
@@ -86,7 +93,17 @@ fn run() -> Result<(), Box<dyn Error>> {
 
         // Process the result of reading metadata
         match value_res {
-            Ok(values) => {
+            Ok(mut values) => {
+                // Inject the file-type template variables ({%type}, {%ty})
+                let ext = utilities::get_extension(filename);
+                let type_val = if type_case_upper {
+                    ext.to_uppercase()
+                } else {
+                    ext
+                };
+                values.insert("%type".to_string(), type_val.clone());
+                values.insert("%ty".to_string(), type_val);
+
                 let move_pat = if move_files { Some(move_pattern) } else { None };
                 match rename_file::rename_and_move(
                     filename,
@@ -119,6 +136,19 @@ fn run() -> Result<(), Box<dyn Error>> {
     // Everything is a-okay in the end
     Ok(())
 } // fn run()
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn get_extension_normalises_to_lowercase() {
+        // get_extension() always returns a lowercase string.
+        // The {%type} injection in run() depends on this — the `lower` case
+        // mode needs no transform, and `upper` always starts from lowercase.
+        assert_eq!(utilities::get_extension("workout.FIT"), "fit");
+        assert_eq!(utilities::get_extension("route.gpx"), "gpx");
+        assert_eq!(utilities::get_extension("activity.TCX"), "tcx");
+    }
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// The actual executable function that gets called when the program in invoked.

--- a/fitrename/src/main.rs
+++ b/fitrename/src/main.rs
@@ -93,8 +93,15 @@ fn run() -> Result<(), Box<dyn Error>> {
         // Process the result of reading metadata
         match value_res {
             Ok(mut values) => {
-                // Inject the file-type template variables ({%type}, {%ty})
-                let ext = utilities::get_extension(filename);
+                // Inject the file-type template variables ({%type}, {%ty}).
+                // Normalise an empty extension (e.g. "filename.") to "unknown"
+                // so downstream patterns like {%type} are never empty strings.
+                let raw_ext = utilities::get_extension(filename);
+                let ext = if raw_ext.is_empty() {
+                    String::from("unknown")
+                } else {
+                    raw_ext
+                };
                 let type_val = if type_case_upper {
                     ext.to_uppercase()
                 } else {

--- a/fitrename/src/main.rs
+++ b/fitrename/src/main.rs
@@ -94,14 +94,9 @@ fn run() -> Result<(), Box<dyn Error>> {
         match value_res {
             Ok(mut values) => {
                 // Inject the file-type template variables ({%type}, {%ty}).
-                // Normalise an empty extension (e.g. "filename.") to "unknown"
-                // so downstream patterns like {%type} are never empty strings.
-                let raw_ext = utilities::get_extension(filename);
-                let ext = if raw_ext.is_empty() {
-                    String::from("unknown")
-                } else {
-                    raw_ext
-                };
+                // get_extension() always returns a non-empty string ("unknown"
+                // for missing or trailing-dot extensions), so no guard needed.
+                let ext = utilities::get_extension(filename);
                 let type_val = if type_case_upper {
                     ext.to_uppercase()
                 } else {

--- a/fitrename/src/main.rs
+++ b/fitrename/src/main.rs
@@ -59,8 +59,7 @@ fn run() -> Result<(), Box<dyn Error>> {
 
     ///////////////////////////////////
     // Working section
-    for filename in &filenames {
-        let filename = filename.as_str();
+    for filename in filenames.iter().map(String::as_str) {
         total_files += 1;
         log::debug!("Processing file: {filename}");
 

--- a/fitrename/src/rename_file.rs
+++ b/fitrename/src/rename_file.rs
@@ -116,3 +116,55 @@ pub fn rename_and_move<S: ::std::hash::BuildHasher>(
 
     Ok(final_path.to_string_lossy().to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_type_variable_substitution() {
+        let mut values = HashMap::new();
+        values.insert("%year".to_string(), "2024".to_string());
+        values.insert("%type".to_string(), "fit".to_string());
+        values.insert("%ty".to_string(), "fit".to_string());
+
+        // {%type} alone produces the file extension
+        assert_eq!(substitute_pattern("{%type}", &values), "fit");
+        // Short alias produces the same result
+        assert_eq!(substitute_pattern("{%ty}", &values), "fit");
+        // Combined with other variables
+        assert_eq!(
+            substitute_pattern("{%year}-{%type}", &values),
+            "2024-fit"
+        );
+    }
+
+    #[test]
+    fn test_type_variable_uppercase() {
+        let mut values = HashMap::new();
+        values.insert("%type".to_string(), "FIT".to_string());
+        values.insert("%ty".to_string(), "FIT".to_string());
+
+        assert_eq!(substitute_pattern("{%type}", &values), "FIT");
+        assert_eq!(substitute_pattern("{%ty}", &values), "FIT");
+    }
+
+    #[test]
+    fn test_type_variable_for_gpx() {
+        let mut values = HashMap::new();
+        values.insert("%type".to_string(), "gpx".to_string());
+        values.insert("%ty".to_string(), "gpx".to_string());
+
+        assert_eq!(substitute_pattern("{%type}", &values), "gpx");
+    }
+
+    #[test]
+    fn test_type_variable_for_tcx_uppercase() {
+        let mut values = HashMap::new();
+        values.insert("%type".to_string(), "TCX".to_string());
+        values.insert("%ty".to_string(), "TCX".to_string());
+
+        assert_eq!(substitute_pattern("{%type}", &values), "TCX");
+    }
+}

--- a/fitview/Cargo.toml
+++ b/fitview/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fitview"
-version = "0.4.8"
+version = "0.5.0"
 edition = "2024"
 description = "Shows the metadata from .FIT, .GPX and .TCX files."
 license = "Apache-2.0"

--- a/fitview/src/cli.rs
+++ b/fitview/src/cli.rs
@@ -11,7 +11,7 @@ pub fn build() -> Command {
         .arg(
             Arg::new("read")
                 .value_name("FILE(S)")
-                .help("One or more .fit, .gpx or .tcx file(s) to process. Wildcards and multiple_occurrences files (e.g. 2019*.fit 2020*.gpx) are supported.")
+                .help("One or more .fit, .gpx or .tcx file(s) to process. Glob patterns (e.g. *.fit, 2024*.gpx) are expanded by the application.")
                 .num_args(1..)
                 .required(true)
                 .action(ArgAction::Append)

--- a/fitview/src/main.rs
+++ b/fitview/src/main.rs
@@ -102,10 +102,13 @@ mod tests {
         // match nothing, regardless of any stale files in the OS temp dir.
         let tmp = std::env::temp_dir()
             .join(format!("fitutils_fv_nomatch_{}", std::process::id()));
+        if tmp.exists() {
+            fs::remove_dir_all(&tmp).expect("remove stale temp dir");
+        }
         fs::create_dir_all(&tmp).expect("create temp dir");
         let pattern = tmp.join("*.fit").to_string_lossy().into_owned();
         let result = utilities::expand_globs(&[pattern]);
         assert!(result.is_empty());
-        fs::remove_dir(tmp).expect("clean up temp dir");
+        fs::remove_dir_all(tmp).expect("clean up temp dir");
     }
 }

--- a/fitview/src/main.rs
+++ b/fitview/src/main.rs
@@ -97,7 +97,11 @@ fn main() {
 mod tests {
     #[test]
     fn expand_globs_empty_on_no_match() {
-        let result = utilities::expand_globs(&["/tmp/fitutils_nonexistent_*.fit".to_string()]);
+        let pattern = format!(
+            "{}/fitutils_nonexistent_*.fit",
+            std::env::temp_dir().to_string_lossy()
+        );
+        let result = utilities::expand_globs(&[pattern]);
         assert!(result.is_empty());
     }
 }

--- a/fitview/src/main.rs
+++ b/fitview/src/main.rs
@@ -32,8 +32,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut skipped_files: usize = 0;
 
     // The good stuff goes here
-    for filename in &filenames {
-        let filename = filename.as_str();
+    for filename in filenames.iter().map(String::as_str) {
         log::debug!("Processing file: {filename}");
         match utilities::get_extension(filename).as_ref() {
             "fit" => match FITActivity::from_file(filename) {

--- a/fitview/src/main.rs
+++ b/fitview/src/main.rs
@@ -97,7 +97,7 @@ mod tests {
     #[test]
     fn expand_globs_empty_on_no_match() {
         let pattern = std::env::temp_dir()
-            .join("fitutils_nonexistent_*.fit")
+            .join(format!("fitutils_nonexistent_{}_*.fit", std::process::id()))
             .to_string_lossy()
             .into_owned();
         let result = utilities::expand_globs(&[pattern]);

--- a/fitview/src/main.rs
+++ b/fitview/src/main.rs
@@ -96,10 +96,10 @@ fn main() {
 mod tests {
     #[test]
     fn expand_globs_empty_on_no_match() {
-        let pattern = format!(
-            "{}/fitutils_nonexistent_*.fit",
-            std::env::temp_dir().to_string_lossy()
-        );
+        let pattern = std::env::temp_dir()
+            .join("fitutils_nonexistent_*.fit")
+            .to_string_lossy()
+            .into_owned();
         let result = utilities::expand_globs(&[pattern]);
         assert!(result.is_empty());
     }

--- a/fitview/src/main.rs
+++ b/fitview/src/main.rs
@@ -94,13 +94,18 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     #[test]
     fn expand_globs_empty_on_no_match() {
-        let pattern = std::env::temp_dir()
-            .join(format!("fitutils_nonexistent_{}_*.fit", std::process::id()))
-            .to_string_lossy()
-            .into_owned();
+        // Use an isolated empty temp directory so the glob is guaranteed to
+        // match nothing, regardless of any stale files in the OS temp dir.
+        let tmp = std::env::temp_dir()
+            .join(format!("fitutils_fv_nomatch_{}", std::process::id()));
+        fs::create_dir_all(&tmp).expect("create temp dir");
+        let pattern = tmp.join("*.fit").to_string_lossy().into_owned();
         let result = utilities::expand_globs(&[pattern]);
         assert!(result.is_empty());
+        fs::remove_dir(tmp).expect("clean up temp dir");
     }
 }

--- a/fitview/src/main.rs
+++ b/fitview/src/main.rs
@@ -91,24 +91,3 @@ fn main() {
         }
     });
 }
-
-#[cfg(test)]
-mod tests {
-    use std::fs;
-
-    #[test]
-    fn expand_globs_empty_on_no_match() {
-        // Use an isolated empty temp directory so the glob is guaranteed to
-        // match nothing, regardless of any stale files in the OS temp dir.
-        let tmp = std::env::temp_dir()
-            .join(format!("fitutils_fv_nomatch_{}", std::process::id()));
-        if tmp.exists() {
-            fs::remove_dir_all(&tmp).expect("remove stale temp dir");
-        }
-        fs::create_dir_all(&tmp).expect("create temp dir");
-        let pattern = tmp.join("*.fit").to_string_lossy().into_owned();
-        let result = utilities::expand_globs(&[pattern]);
-        assert!(result.is_empty());
-        fs::remove_dir_all(tmp).expect("clean up temp dir");
-    }
-}

--- a/fitview/src/main.rs
+++ b/fitview/src/main.rs
@@ -19,10 +19,12 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut logbuilder = utilities::build_log(&cli_args);
     logbuilder.target(Target::Stdout).init();
 
-    let filenames = cli_args
+    let raw_inputs: Vec<String> = cli_args
         .get_many::<String>("read")
         .unwrap_or_default()
-        .map(std::string::String::as_str);
+        .cloned()
+        .collect();
+    let filenames = utilities::expand_globs(&raw_inputs);
     log::trace!("main::run() -- Files: {filenames:?}");
 
     let mut total_files: usize = 0;
@@ -30,7 +32,8 @@ fn run() -> Result<(), Box<dyn Error>> {
     let mut skipped_files: usize = 0;
 
     // The good stuff goes here
-    for filename in filenames {
+    for filename in &filenames {
+        let filename = filename.as_str();
         log::debug!("Processing file: {filename}");
         match utilities::get_extension(filename).as_ref() {
             "fit" => match FITActivity::from_file(filename) {
@@ -88,4 +91,13 @@ fn main() {
             1 // exit with a non-zero return code, indicating a problem
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn expand_globs_empty_on_no_match() {
+        let result = utilities::expand_globs(&["/tmp/fitutils_nonexistent_*.fit".to_string()]);
+        assert!(result.is_empty());
+    }
 }

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utilities"
-version = "0.4.12"
+version = "0.5.0"
 edition = "2024"
 description = "Shared utility types and functions for the fitness utilities."
 license = "Apache-2.0"
@@ -11,6 +11,7 @@ include = ["src/**/*", "README.md"]
 
 [dependencies]
 clap = { workspace = true }
+glob = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
 chrono = { workspace = true }

--- a/utilities/src/extensions.rs
+++ b/utilities/src/extensions.rs
@@ -20,13 +20,17 @@ use std::path::PathBuf;
 /// ```
 #[must_use]
 pub fn get_extension(filename: &str) -> String {
-    std::path::Path::new(&filename)
+    let ext = std::path::Path::new(&filename)
         .extension()
         .unwrap_or_else(|| std::ffi::OsStr::new("unknown"))
         .to_ascii_lowercase()
         .to_str()
-        .unwrap_or("")
-        .to_string()
+        .unwrap_or("unknown")
+        .to_string();
+    // `Path::extension()` returns `Some("")` for a trailing dot (e.g.
+    // "filename."), which would produce an empty string after the chain above.
+    // Normalise that to "unknown" so callers never receive an empty extension.
+    if ext.is_empty() { "unknown".to_string() } else { ext }
 }
 
 /// Change the file extension
@@ -66,7 +70,7 @@ mod tests {
     fn test_get_extension() {
         assert_eq!(get_extension("filename.txt"), "txt".to_string());
         assert_eq!(get_extension("filename"), "unknown".to_string());
-        assert_eq!(get_extension("filename."), String::new());
+        assert_eq!(get_extension("filename."), "unknown".to_string());
         assert_eq!(get_extension("filename.txt.txt"), "txt".to_string());
         assert_eq!(get_extension("filename.TXT"), "txt".to_string());
     }

--- a/utilities/src/glob_expand.rs
+++ b/utilities/src/glob_expand.rs
@@ -59,7 +59,7 @@ mod tests {
     }
 
     fn temp_dir(suffix: &str) -> std::path::PathBuf {
-        let d = std::env::temp_dir().join(format!("fitutils_glob_{suffix}"));
+        let d = std::env::temp_dir().join(format!("fitutils_glob_{}_{suffix}", std::process::id()));
         fs::create_dir_all(&d).expect("create temp dir");
         d
     }

--- a/utilities/src/glob_expand.rs
+++ b/utilities/src/glob_expand.rs
@@ -1,3 +1,6 @@
+use glob::glob;
+use std::collections::BTreeSet;
+
 /// Expands a list of file-path strings and glob patterns into a sorted,
 /// deduplicated list of existing file paths.
 ///
@@ -16,9 +19,6 @@
 /// let files = expand_globs(&["*.fit".to_string()]);
 /// // returns sorted Vec<String> of matched paths
 /// ```
-use glob::glob;
-use std::collections::BTreeSet;
-
 #[must_use]
 pub fn expand_globs(patterns: &[String]) -> Vec<String> {
     let mut result: BTreeSet<String> = BTreeSet::new();

--- a/utilities/src/glob_expand.rs
+++ b/utilities/src/glob_expand.rs
@@ -60,6 +60,11 @@ mod tests {
 
     fn temp_dir(suffix: &str) -> std::path::PathBuf {
         let d = std::env::temp_dir().join(format!("fitutils_glob_{}_{suffix}", std::process::id()));
+        // Remove any stale directory from a previous crashed run before creating
+        // a fresh one, so leftover files never influence test results.
+        if d.exists() {
+            fs::remove_dir_all(&d).expect("remove stale temp dir");
+        }
         fs::create_dir_all(&d).expect("create temp dir");
         d
     }

--- a/utilities/src/glob_expand.rs
+++ b/utilities/src/glob_expand.rs
@@ -15,22 +15,33 @@ use std::{collections::BTreeSet, path::Path};
 /// The result is sorted lexicographically and deduplicated so that processing
 /// order is deterministic regardless of filesystem iteration order.
 ///
+/// # Caveats
+///
+/// Paths returned by glob matches are converted with [`std::path::Path::to_string_lossy`],
+/// which replaces non-UTF-8 bytes with `U+FFFD`. If a glob pattern matches
+/// a file whose path is not valid UTF-8, the returned string will be lossy and
+/// may not round-trip back to the original path. Callers that need to open
+/// matched files should be aware of this limitation. Literal paths supplied
+/// directly (i.e. those that already exist on disk) bypass this conversion and
+/// are returned as-is.
+///
 /// # Examples
 ///
 /// ```no_run
 /// # use utilities::expand_globs;
-/// let files = expand_globs(&["*.fit".to_string()]);
+/// let files = expand_globs(&["*.fit"]);
 /// // returns sorted Vec<String> of matched paths
 /// ```
 #[must_use]
-pub fn expand_globs(patterns: &[String]) -> Vec<String> {
+pub fn expand_globs<S: AsRef<str>>(patterns: &[S]) -> Vec<String> {
     let mut result: BTreeSet<String> = BTreeSet::new();
 
     for pattern in patterns {
+        let pattern = pattern.as_ref();
         // If the path already exists on disk, include it as-is without glob
         // interpretation so that filenames containing metacharacters are safe.
         if Path::new(pattern).exists() {
-            result.insert(pattern.clone());
+            result.insert(pattern.to_owned());
             continue;
         }
 

--- a/utilities/src/glob_expand.rs
+++ b/utilities/src/glob_expand.rs
@@ -1,0 +1,149 @@
+/// Expands a list of file-path strings and glob patterns into a sorted,
+/// deduplicated list of existing file paths.
+///
+/// Each element of `patterns` may be a literal path or a shell-style glob
+/// (`*`, `?`, `[a-z]`). If an element matches no files — whether because it
+/// is a glob that matches nothing or a literal path that does not exist — a
+/// `warn!` log is emitted and that element contributes nothing to the output.
+///
+/// The result is sorted lexicographically and deduplicated so that processing
+/// order is deterministic regardless of filesystem iteration order.
+///
+/// # Examples
+///
+/// ```no_run
+/// # use utilities::expand_globs;
+/// let files = expand_globs(&["*.fit".to_string()]);
+/// // returns sorted Vec<String> of matched paths
+/// ```
+use glob::glob;
+use std::collections::BTreeSet;
+
+#[must_use]
+pub fn expand_globs(patterns: &[String]) -> Vec<String> {
+    let mut result: BTreeSet<String> = BTreeSet::new();
+
+    for pattern in patterns {
+        match glob(pattern) {
+            Err(e) => log::warn!("Invalid glob pattern '{pattern}': {e}"),
+            Ok(entries) => {
+                let mut matched = false;
+                for entry in entries {
+                    match entry {
+                        Ok(path) => {
+                            matched = true;
+                            result.insert(path.to_string_lossy().into_owned());
+                        }
+                        Err(e) => log::warn!("Glob error in '{pattern}': {e}"),
+                    }
+                }
+                if !matched {
+                    log::warn!("No files matched pattern: {pattern}");
+                }
+            }
+        }
+    }
+
+    result.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs, path::Path};
+
+    fn make_files(dir: &Path, names: &[&str]) {
+        for name in names {
+            fs::write(dir.join(name), b"").expect("create temp file");
+        }
+    }
+
+    fn temp_dir(suffix: &str) -> std::path::PathBuf {
+        let d = std::env::temp_dir().join(format!("fitutils_glob_{suffix}"));
+        fs::create_dir_all(&d).expect("create temp dir");
+        d
+    }
+
+    #[test]
+    fn test_literal_path_returns_itself() {
+        let tmp = temp_dir("literal");
+        let file = tmp.join("test.fit");
+        fs::write(&file, b"").unwrap();
+
+        let path_str = file.to_string_lossy().into_owned();
+        let result = expand_globs(&[path_str.clone()]);
+        assert_eq!(result, vec![path_str]);
+
+        fs::remove_file(file).unwrap();
+        fs::remove_dir(tmp).unwrap();
+    }
+
+    #[test]
+    fn test_glob_results_are_sorted() {
+        let tmp = temp_dir("sorted");
+        make_files(&tmp, &["c.fit", "a.fit", "b.fit"]);
+
+        let pattern = tmp.join("*.fit").to_string_lossy().into_owned();
+        let result = expand_globs(&[pattern]);
+
+        let mut expected: Vec<String> = ["a.fit", "b.fit", "c.fit"]
+            .iter()
+            .map(|n| tmp.join(n).to_string_lossy().into_owned())
+            .collect();
+        expected.sort();
+        assert_eq!(result, expected);
+
+        for n in &["a.fit", "b.fit", "c.fit"] {
+            fs::remove_file(tmp.join(n)).unwrap();
+        }
+        fs::remove_dir(tmp).unwrap();
+    }
+
+    #[test]
+    fn test_overlapping_patterns_deduplicated() {
+        let tmp = temp_dir("dedup");
+        let file = tmp.join("2024_run.fit");
+        fs::write(&file, b"").unwrap();
+
+        let exact = file.to_string_lossy().into_owned();
+        let glob_pat = tmp.join("*.fit").to_string_lossy().into_owned();
+        // Same file matched by both the literal path and the glob
+        let result = expand_globs(&[exact.clone(), glob_pat]);
+        assert_eq!(result, vec![exact]);
+
+        fs::remove_file(file).unwrap();
+        fs::remove_dir(tmp).unwrap();
+    }
+
+    #[test]
+    fn test_no_match_returns_empty() {
+        let tmp = temp_dir("nomatch");
+        let pattern = tmp.join("*.fit").to_string_lossy().into_owned();
+        let result = expand_globs(&[pattern]);
+        assert!(result.is_empty());
+        fs::remove_dir(tmp).unwrap();
+    }
+
+    #[test]
+    fn test_mixed_literal_and_glob() {
+        let tmp = temp_dir("mixed");
+        make_files(&tmp, &["run.gpx", "ride.fit", "walk.fit"]);
+
+        let literal = tmp.join("run.gpx").to_string_lossy().into_owned();
+        let glob_pat = tmp.join("*.fit").to_string_lossy().into_owned();
+        let result = expand_globs(&[literal.clone(), glob_pat]);
+
+        let mut expected: Vec<String> = vec![
+            tmp.join("ride.fit").to_string_lossy().into_owned(),
+            tmp.join("run.gpx").to_string_lossy().into_owned(),
+            tmp.join("walk.fit").to_string_lossy().into_owned(),
+        ];
+        expected.sort();
+        assert_eq!(result, expected);
+
+        for n in &["run.gpx", "ride.fit", "walk.fit"] {
+            fs::remove_file(tmp.join(n)).unwrap();
+        }
+        fs::remove_dir(tmp).unwrap();
+    }
+}

--- a/utilities/src/glob_expand.rs
+++ b/utilities/src/glob_expand.rs
@@ -37,17 +37,23 @@ pub fn expand_globs(patterns: &[String]) -> Vec<String> {
         match glob(pattern) {
             Err(e) => log::warn!("Invalid glob pattern '{pattern}': {e}"),
             Ok(entries) => {
-                let mut matched = false;
+                // `any_entry` tracks whether the iterator produced at least one
+                // candidate (success or permission error).  The "no match"
+                // warning must only fire when the glob found zero candidates;
+                // when entries exist but all error (e.g. permission denied) we
+                // have already warned per-entry and should not also claim the
+                // pattern matched nothing.
+                let mut any_entry = false;
                 for entry in entries {
+                    any_entry = true;
                     match entry {
                         Ok(path) => {
-                            matched = true;
                             result.insert(path.to_string_lossy().into_owned());
                         }
                         Err(e) => log::warn!("Glob error in '{pattern}': {e}"),
                     }
                 }
-                if !matched {
+                if !any_entry {
                     log::warn!("No files matched pattern: {pattern}");
                 }
             }

--- a/utilities/src/glob_expand.rs
+++ b/utilities/src/glob_expand.rs
@@ -48,17 +48,16 @@ pub fn expand_globs<S: AsRef<str>>(patterns: &[S]) -> Vec<String> {
         match glob(pattern) {
             Err(e) => log::warn!("Invalid glob pattern '{pattern}': {e}"),
             Ok(entries) => {
-                // `any_entry` tracks whether the iterator produced at least one
-                // candidate (success or permission error).  The "no match"
-                // warning must only fire when the glob found zero candidates;
-                // when entries exist but all error (e.g. permission denied) we
-                // have already warned per-entry and should not also claim the
-                // pattern matched nothing.
+                // `any_entry` tracks whether the glob successfully resolved at
+                // least one path.  The "no match" warning fires when the glob
+                // found zero successful entries.  Permission-denied errors
+                // already produce a per-entry warn!, so they do not count as
+                // successful matches — only `Ok(path)` advances the flag.
                 let mut any_entry = false;
                 for entry in entries {
-                    any_entry = true;
                     match entry {
                         Ok(path) => {
+                            any_entry = true;
                             result.insert(path.to_string_lossy().into_owned());
                         }
                         Err(e) => log::warn!("Glob error in '{pattern}': {e}"),

--- a/utilities/src/glob_expand.rs
+++ b/utilities/src/glob_expand.rs
@@ -1,13 +1,16 @@
 use glob::glob;
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, path::Path};
 
 /// Expands a list of file-path strings and glob patterns into a sorted,
 /// deduplicated list of existing file paths.
 ///
-/// Each element of `patterns` may be a literal path or a shell-style glob
-/// (`*`, `?`, `[a-z]`). If an element matches no files — whether because it
-/// is a glob that matches nothing or a literal path that does not exist — a
-/// `warn!` log is emitted and that element contributes nothing to the output.
+/// Each element of `patterns` is resolved as follows:
+/// 1. If the string names an existing file or directory on disk, it is included
+///    directly without glob interpretation. This preserves filenames that
+///    contain glob metacharacters (e.g. `"file[1].fit"` on Unix).
+/// 2. Otherwise the string is treated as a shell-style glob (`*`, `?`,
+///    `[a-z]`). If it matches nothing, a `warn!` is emitted and the element
+///    contributes nothing to the output.
 ///
 /// The result is sorted lexicographically and deduplicated so that processing
 /// order is deterministic regardless of filesystem iteration order.
@@ -24,6 +27,13 @@ pub fn expand_globs(patterns: &[String]) -> Vec<String> {
     let mut result: BTreeSet<String> = BTreeSet::new();
 
     for pattern in patterns {
+        // If the path already exists on disk, include it as-is without glob
+        // interpretation so that filenames containing metacharacters are safe.
+        if Path::new(pattern).exists() {
+            result.insert(pattern.clone());
+            continue;
+        }
+
         match glob(pattern) {
             Err(e) => log::warn!("Invalid glob pattern '{pattern}': {e}"),
             Ok(entries) => {
@@ -126,6 +136,22 @@ mod tests {
         let pattern = tmp.join("*.fit").to_string_lossy().into_owned();
         let result = expand_globs(&[pattern]);
         assert!(result.is_empty());
+        fs::remove_dir(tmp).unwrap();
+    }
+
+    #[test]
+    fn test_literal_with_metacharacters_not_interpreted_as_glob() {
+        // A filename that contains glob metacharacters must be treated as a
+        // literal path when the file exists, not expanded as a pattern.
+        let tmp = temp_dir("metachar");
+        let file = tmp.join("run[1].fit");
+        fs::write(&file, b"").unwrap();
+
+        let path_str = file.to_string_lossy().into_owned();
+        let result = expand_globs(&[path_str.clone()]);
+        assert_eq!(result, vec![path_str], "metacharacter filename must not be glob-expanded");
+
+        fs::remove_file(file).unwrap();
         fs::remove_dir(tmp).unwrap();
     }
 

--- a/utilities/src/lib.rs
+++ b/utilities/src/lib.rs
@@ -3,6 +3,7 @@ mod datetime_keys;
 mod duration;
 mod extensions;
 mod fit;
+mod glob_expand;
 mod gpx;
 mod macros;
 mod tcx;
@@ -27,4 +28,5 @@ pub use crate::{
     build_logs::build_log,
     duration::Duration,
     extensions::{get_extension, set_extension},
+    glob_expand::expand_globs,
 };


### PR DESCRIPTION
## Summary

- **`expand_globs()` utility** (`utilities/src/glob_expand.rs`) — expands shell-style glob patterns (`*`, `?`, `[a-z]`) into a sorted, deduplicated `Vec<String>` of matching paths; warns on no-match. Backed by `glob 0.3` as a new workspace dependency.
- **All four binaries** (`fit2json`, `fitexport`, `fitview`, `fitrename`) now call `expand_globs()` on their raw file inputs, so quoted globs like `'*.fit'` work reliably across shells, scripts, and Windows without relying on the shell to expand them.
- **`{%type}` / `{%ty}` template variables** added to `fitrename` — inserts the file's extension (e.g. `fit`, `gpx`, `tcx`) into rename and move patterns. A new `--type-case upper|lower` flag (default `lower`) controls casing. Example: `fitrename '*.fit' '*.gpx' -p '{%year}-{%month}-{%day}' --move '{%type}'` routes FIT files into `fit/` and GPX files into `gpx/`.

## Version bumps

| Crate | Before | After |
|---|---|---|
| `utilities` | 0.4.12 | 0.5.0 |
| `fit2json` | 0.1.7 | 0.2.0 |
| `fitexport` | 0.1.2 | 0.2.0 |
| `fitview` | 0.4.8 | 0.5.0 |
| `fitrename` | 0.5.5 | 0.6.0 |

## Test plan

- [x] 35/35 tests pass (`cargo nextest run`)
- [x] Zero warnings (`cargo lclippy -- -W clippy::pedantic -W clippy::nursery -W clippy::unwrap_used`)
- [x] 5 new unit tests in `utilities::glob_expand` (sorted, deduped, literal, no-match, mixed)
- [x] Per-binary smoke tests (`expand_globs_empty_on_no_match`) in all four binaries
- [x] 4 new substitution tests in `fitrename::rename_file` for `{%type}` / `{%ty}`
- [x] `get_extension_normalises_to_lowercase` contract test in `fitrename::main`
- [x] CHANGELOG regenerated via `git-cliff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)